### PR TITLE
Add tray control, notifications, and media integrations

### DIFF
--- a/soundcloud-wrapper-tauri/src-tauri/Cargo.lock
+++ b/soundcloud-wrapper-tauri/src-tauri/Cargo.lock
@@ -57,13 +57,144 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
 dependencies = [
  "atk-sys",
- "glib",
+ "glib 0.18.5",
  "libc",
 ]
 
@@ -73,8 +204,8 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "system-deps",
 ]
@@ -161,6 +292,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,7 +360,7 @@ checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
  "bitflags 2.9.4",
  "cairo-sys-rs",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "thiserror 1.0.69",
@@ -228,7 +372,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
  "system-deps",
 ]
@@ -344,6 +488,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -518,6 +671,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b5f0f36f1eebe901b0e6bee369a77ed3396334bf3f09abd46454a576f71819"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +850,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +902,33 @@ dependencies = [
  "libc",
  "windows-sys 0.61.0",
 ]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -833,6 +1050,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,7 +1121,7 @@ dependencies = [
  "gdk-pixbuf",
  "gdk-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "pango",
 ]
@@ -904,7 +1134,7 @@ checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
 ]
@@ -916,8 +1146,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
 dependencies = [
  "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "system-deps",
 ]
@@ -931,8 +1161,8 @@ dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
  "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pango-sys",
  "pkg-config",
@@ -946,8 +1176,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69"
 dependencies = [
  "gdk-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pkg-config",
  "system-deps",
@@ -962,7 +1192,7 @@ dependencies = [
  "gdk",
  "gdkx11-sys",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "x11",
 ]
@@ -974,7 +1204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
 dependencies = [
  "gdk-sys",
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
  "system-deps",
  "x11",
@@ -1051,7 +1281,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "gio-sys",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "pin-project-lite",
@@ -1065,11 +1295,31 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "system-deps",
  "winapi",
+]
+
+[[package]]
+name = "glib"
+version = "0.15.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb0306fbad0ab5428b0ca674a23893db909a98582969c9b537be4ced78c505d"
+dependencies = [
+ "bitflags 1.3.2",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "glib-macros 0.15.13",
+ "glib-sys 0.15.10",
+ "gobject-sys 0.15.10",
+ "libc",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1085,14 +1335,29 @@ dependencies = [
  "futures-task",
  "futures-util",
  "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
+ "glib-macros 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "memchr",
  "once_cell",
  "smallvec",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.15.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10c6ae9f6fa26f4fb2ac16b528d138d971ead56141de489f8111e259b9df3c4a"
+dependencies = [
+ "anyhow",
+ "heck 0.4.1",
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1107,6 +1372,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4b192f8e65e9cf76cbf4ea71fa8e3be4a0e18ffe3d68b8da6836974cc5bad4"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1145,11 +1420,22 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
+version = "0.15.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d57ce44246becd17153bd035ab4d32cfee096a657fc01f2231c9278378d1e0a"
+dependencies = [
+ "glib-sys 0.15.10",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
- "glib-sys",
+ "glib-sys 0.18.1",
  "libc",
  "system-deps",
 ]
@@ -1167,7 +1453,7 @@ dependencies = [
  "gdk",
  "gdk-pixbuf",
  "gio",
- "glib",
+ "glib 0.18.5",
  "gtk-sys",
  "gtk3-macros",
  "libc",
@@ -1186,8 +1472,8 @@ dependencies = [
  "gdk-pixbuf-sys",
  "gdk-sys",
  "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "pango-sys",
  "system-deps",
@@ -1229,6 +1515,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1571,7 +1863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc"
 dependencies = [
  "bitflags 1.3.2",
- "glib",
+ "glib 0.18.5",
  "javascriptcore-rs-sys",
 ]
 
@@ -1581,8 +1873,8 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "system-deps",
 ]
@@ -1676,7 +1968,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
 dependencies = [
- "glib",
+ "glib 0.18.5",
  "gtk",
  "gtk-sys",
  "libappindicator-sys",
@@ -1699,6 +1991,15 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbe856efeb50e4681f010e9aaa2bf0a644e10139e54cde10fc83a307c23bd9f"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -1753,6 +2054,18 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119c8490084af61b44c9eda9d626475847a186737c0378c85e32d77c33a01cd4"
+dependencies = [
+ "cc",
+ "objc2 0.6.2",
+ "objc2-foundation 0.3.1",
+ "time",
+]
 
 [[package]]
 name = "markup5ever"
@@ -1828,6 +2141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpris-player"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d661d96b263756adec7ca7035a5c03d7a0d11a54619e99f8a2eb108a3d0391d1"
+dependencies = [
+ "dbus",
+ "glib 0.15.12",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,10 +2208,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify-rust"
+version = "4.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
 
 [[package]]
 name = "num-conv"
@@ -2198,6 +2548,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,7 +2574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
 dependencies = [
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "once_cell",
  "pango-sys",
@@ -2226,11 +2586,17 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
 dependencies = [
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2414,6 +2780,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,7 +2804,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.11.3",
- "quick-xml",
+ "quick-xml 0.38.3",
  "serde",
  "time",
 ]
@@ -2443,6 +2820,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2545,6 +2936,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
@@ -2593,6 +2993,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,6 +3023,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +3048,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -3187,11 +3616,19 @@ dependencies = [
 name = "soundcloud-wrapper-tauri"
 version = "0.1.0"
 dependencies = [
+ "glib 0.15.12",
+ "mpris-player",
+ "objc2 0.6.2",
+ "objc2-foundation 0.3.1",
+ "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-global-shortcut",
+ "tauri-plugin-notification",
  "tauri-plugin-shell",
  "url",
+ "windows",
 ]
 
 [[package]]
@@ -3202,7 +3639,7 @@ checksum = "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f"
 dependencies = [
  "futures-channel",
  "gio",
- "glib",
+ "glib 0.18.5",
  "libc",
  "soup3-sys",
 ]
@@ -3214,8 +3651,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27"
 dependencies = [
  "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "libc",
  "system-deps",
 ]
@@ -3225,6 +3662,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3528,6 +3971,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-notification"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fbc86b929b5376ab84b25c060f966d146b2fbd59b6af8264027b343c82c219"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.16",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3646,6 +4108,31 @@ checksum = "fd21509dd1fa9bd355dc29894a6ff10635880732396aa38c0066c1e6c1ab8074"
 dependencies = [
  "embed-resource",
  "toml 0.9.6",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.16",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3917,7 +4404,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3968,6 +4467,17 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -4258,9 +4768,9 @@ dependencies = [
  "gdk-sys",
  "gio",
  "gio-sys",
- "glib",
- "glib-sys",
- "gobject-sys",
+ "glib 0.18.5",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "gtk",
  "gtk-sys",
  "javascriptcore-rs",
@@ -4280,8 +4790,8 @@ dependencies = [
  "cairo-sys-rs",
  "gdk-sys",
  "gio-sys",
- "glib-sys",
- "gobject-sys",
+ "glib-sys 0.18.1",
+ "gobject-sys 0.18.0",
  "gtk-sys",
  "javascriptcore-rs-sys",
  "libc",
@@ -4905,6 +5415,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d07e46d035fb8e375b2ce63ba4e4ff90a7f73cf2ffb0138b29e1158d2eaadf7"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.60.2",
+ "winnow 0.7.13",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e797a9c847ed3ccc5b6254e8bcce056494b375b511b3d6edcec0aeb4defaca"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.7.13",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4976,4 +5546,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.13",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.106",
+ "winnow 0.7.13",
 ]

--- a/soundcloud-wrapper-tauri/src-tauri/Cargo.toml
+++ b/soundcloud-wrapper-tauri/src-tauri/Cargo.toml
@@ -17,8 +17,39 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
+[features]
+default = []
+mpris-linux = ["glib", "mpris-player"]
+
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-shell = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-notification = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 url = "2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+glib = { version = "0.15", features = ["v2_58"], optional = true }
+mpris-player = { version = "0.6", optional = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = [
+    "Foundation",
+    "Media",
+    "Media_MediaProperties",
+    "Media_Playback",
+    "Storage",
+    "Storage_Streams",
+    "Win32_Foundation",
+    "Win32_System_WinRT",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = [
+    "NSDictionary",
+    "NSAutoreleasePool",
+    "NSString",
+] }

--- a/soundcloud-wrapper-tauri/src-tauri/src/media.rs
+++ b/soundcloud-wrapper-tauri/src-tauri/src/media.rs
@@ -1,0 +1,521 @@
+use serde::Deserialize;
+use tauri::AppHandle;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaMetadataPayload {
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    #[serde(alias = "artwork", default)]
+    pub artwork: Option<Vec<ArtworkEntry>>, // used for parsing arrays in JS payload
+    #[serde(alias = "artworkUrl")]
+    pub artwork_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ArtworkEntry {
+    pub src: Option<String>,
+}
+
+impl MediaMetadataPayload {
+    pub fn into_metadata(self) -> MediaMetadata {
+        let artwork_url = if let Some(url) = self.artwork_url {
+            Some(url)
+        } else {
+            self.artwork
+                .and_then(|entries| entries.into_iter().find_map(|entry| entry.src))
+        };
+
+        MediaMetadata {
+            title: self.title,
+            artist: self.artist,
+            album: self.album,
+            artwork_url,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaUpdatePayload {
+    pub playback_state: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<MediaMetadataPayload>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ThemeChangePayload {
+    pub theme: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<MediaMetadataPayload>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MediaMetadata {
+    pub title: Option<String>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub artwork_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaybackStatus {
+    Playing,
+    Paused,
+    Stopped,
+}
+
+impl Default for PlaybackStatus {
+    fn default() -> Self {
+        PlaybackStatus::Paused
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MediaUpdate {
+    pub playback: PlaybackStatus,
+    pub metadata: Option<MediaMetadata>,
+}
+
+impl MediaUpdate {
+    pub fn from_payload(payload: MediaUpdatePayload) -> Option<Self> {
+        let playback = payload
+            .playback_state
+            .as_deref()
+            .and_then(PlaybackStatus::from_str)
+            .unwrap_or_default();
+
+        let metadata = payload.metadata.map(MediaMetadataPayload::into_metadata);
+        if metadata.is_none() && payload.playback_state.is_none() {
+            None
+        } else {
+            Some(MediaUpdate { playback, metadata })
+        }
+    }
+
+    pub fn playback(&self) -> PlaybackStatus {
+        self.playback
+    }
+
+    pub fn metadata(&self) -> Option<&MediaMetadata> {
+        self.metadata.as_ref()
+    }
+}
+
+impl PlaybackStatus {
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "playing" => Some(PlaybackStatus::Playing),
+            "paused" => Some(PlaybackStatus::Paused),
+            "stopped" => Some(PlaybackStatus::Stopped),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MediaCache {
+    pub playback: PlaybackStatus,
+    pub metadata: Option<MediaMetadata>,
+}
+
+impl MediaCache {
+    pub fn update(&mut self, update: &MediaUpdate) {
+        self.playback = update.playback;
+        if let Some(metadata) = &update.metadata {
+            self.metadata = Some(metadata.clone());
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct MediaIntegration {
+    #[cfg(target_os = "linux")]
+    linux: Option<linux::LinuxIntegration>,
+    #[cfg(target_os = "windows")]
+    windows: Option<windows::WindowsIntegration>,
+    #[cfg(target_os = "macos")]
+    macos: Option<macos::MacIntegration>,
+}
+
+impl MediaIntegration {
+    pub fn initialize(app: &AppHandle) -> Self {
+        Self {
+            #[cfg(target_os = "linux")]
+            linux: linux::LinuxIntegration::new(app),
+            #[cfg(target_os = "windows")]
+            windows: windows::WindowsIntegration::new(app),
+            #[cfg(target_os = "macos")]
+            macos: macos::MacIntegration::new(),
+        }
+    }
+
+    pub fn update(&self, update: &MediaUpdate) {
+        #[cfg(target_os = "linux")]
+        if let Some(integration) = &self.linux {
+            integration.update(update);
+        }
+
+        #[cfg(target_os = "windows")]
+        if let Some(integration) = &self.windows {
+            integration.update(update);
+        }
+
+        #[cfg(target_os = "macos")]
+        if let Some(integration) = &self.macos {
+            integration.update(update);
+        }
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "mpris-linux"))]
+mod linux {
+    use super::*;
+    use crate::{
+        emit_media_event, MEDIA_NEXT_EVENT, MEDIA_PAUSE_EVENT, MEDIA_PLAY_EVENT, MEDIA_PREVIOUS_EVENT, MEDIA_TOGGLE_EVENT,
+    };
+    use glib::{source::Priority, Continue, MainContext, MainLoop};
+    use mpris_player::{LoopStatus, Metadata as MprisMetadata, MprisPlayer, PlaybackStatus as MprisPlaybackStatus};
+    use std::sync::mpsc;
+
+    #[derive(Debug, Clone)]
+    enum Command {
+        Update(MediaUpdate),
+    }
+
+    #[derive(Clone)]
+    pub struct LinuxIntegration {
+        sender: glib::Sender<Command>,
+    }
+
+    impl LinuxIntegration {
+        pub fn new(app: &AppHandle) -> Option<Self> {
+            let (ready_tx, ready_rx) = mpsc::channel();
+            let app = app.clone();
+
+            std::thread::spawn(move || {
+                if let Err(error) = Self::run(app, ready_tx) {
+                    eprintln!("[soundcloud-wrapper] Failed to initialize MPRIS service: {error}");
+                }
+            });
+
+            ready_rx.recv().ok().map(|sender| Self { sender })
+        }
+
+        pub fn update(&self, update: &MediaUpdate) {
+            let _ = self.sender.send(Command::Update(update.clone()));
+        }
+
+        fn run(app: AppHandle, ready_tx: mpsc::Sender<glib::Sender<Command>>) -> Result<(), String> {
+            let context = MainContext::new();
+            let _guard = context
+                .acquire()
+                .map_err(|_| "failed to acquire GLib main context".to_string())?;
+
+            let main_loop = MainLoop::new(Some(&context), false);
+
+            let player = MprisPlayer::new(
+                "soundcloudwrapper".to_string(),
+                "SoundCloud Wrapper".to_string(),
+                "soundcloud-wrapper".to_string(),
+            );
+
+            player.set_can_raise(true);
+            player.set_can_quit(false);
+            player.set_can_play(true);
+            player.set_can_pause(true);
+            player.set_can_go_next(true);
+            player.set_can_go_previous(true);
+            player.set_can_seek(false);
+            player.set_can_control(true);
+            player.set_has_track_list(false);
+            player.set_loop_status(LoopStatus::None);
+
+            {
+                let handle = app.clone();
+                player.connect_play(move || emit_media_event(&handle, MEDIA_PLAY_EVENT));
+            }
+            {
+                let handle = app.clone();
+                player.connect_pause(move || emit_media_event(&handle, MEDIA_PAUSE_EVENT));
+            }
+            {
+                let handle = app.clone();
+                player.connect_play_pause(move || emit_media_event(&handle, MEDIA_TOGGLE_EVENT));
+            }
+            {
+                let handle = app.clone();
+                player.connect_next(move || emit_media_event(&handle, MEDIA_NEXT_EVENT));
+            }
+            {
+                let handle = app.clone();
+                player.connect_previous(move || emit_media_event(&handle, MEDIA_PREVIOUS_EVENT));
+            }
+
+            let (sender, receiver) = MainContext::channel::<Command>(Priority::default());
+            ready_tx
+                .send(sender)
+                .map_err(|_| "failed to send MPRIS channel".to_string())?;
+
+            receiver.attach(Some(&context), move |command| {
+                match command {
+                    Command::Update(update) => apply_update(&player, &update),
+                }
+                Continue(true)
+            });
+
+            main_loop.run();
+            Ok(())
+        }
+    }
+
+    fn apply_update(player: &MprisPlayer, update: &MediaUpdate) {
+        let status = match update.playback {
+            PlaybackStatus::Playing => MprisPlaybackStatus::Playing,
+            PlaybackStatus::Paused => MprisPlaybackStatus::Paused,
+            PlaybackStatus::Stopped => MprisPlaybackStatus::Stopped,
+        };
+        player.set_playback_status(status);
+
+        if let Some(metadata) = &update.metadata {
+            let mut payload = MprisMetadata::new();
+            payload.title = metadata.title.clone();
+            payload.artist = metadata
+                .artist
+                .clone()
+                .map(|artist| vec![artist])
+                .or_else(|| metadata.title.clone().map(|title| vec![title]));
+            payload.album = metadata.album.clone();
+            payload.art_url = metadata.artwork_url.clone();
+            player.set_metadata(payload);
+        }
+    }
+}
+
+#[cfg(all(target_os = "linux", not(feature = "mpris-linux")))]
+mod linux {
+    use super::*;
+
+    pub struct LinuxIntegration;
+
+    impl LinuxIntegration {
+        pub fn new(_app: &AppHandle) -> Option<Self> {
+            eprintln!(
+                "[soundcloud-wrapper] MPRIS integration disabled. Enable the 'mpris-linux' feature and install GLib development files to activate."
+            );
+            None
+        }
+
+        pub fn update(&self, _update: &MediaUpdate) {}
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use super::*;
+    use crate::{emit_media_event, MEDIA_NEXT_EVENT, MEDIA_PAUSE_EVENT, MEDIA_PLAY_EVENT, MEDIA_PREVIOUS_EVENT};
+    use tauri::Manager;
+    use windows::core::{factory, HSTRING};
+    use windows::Foundation::{TypedEventHandler, Uri};
+    use windows::Media::MediaPlaybackStatus;
+    use windows::Media::Playback::MediaPlaybackType;
+    use windows::Media::SystemMediaTransportControls;
+    use windows::Media::SystemMediaTransportControlsButton;
+    use windows::Media::SystemMediaTransportControlsDisplayUpdater;
+    use windows::Media::SystemMediaTransportControlsProperty;
+    use windows::Media::SystemMediaTransportControlsTimelineProperties;
+    use windows::Storage::Streams::RandomAccessStreamReference;
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::System::WinRT::ISystemMediaTransportControlsInterop;
+
+    pub struct WindowsIntegration {
+        smtc: SystemMediaTransportControls,
+        _button_token: i64,
+        _property_token: i64,
+    }
+
+    impl WindowsIntegration {
+        pub fn new(app: &AppHandle) -> Option<Self> {
+            let window = app.get_window("main")?;
+            let hwnd = window.hwnd().ok()?;
+
+            let interop: ISystemMediaTransportControlsInterop = factory::<
+                SystemMediaTransportControls,
+                ISystemMediaTransportControlsInterop,
+            >()
+            .ok()?;
+
+            let smtc: SystemMediaTransportControls = unsafe { interop.GetForWindow::<SystemMediaTransportControls>(HWND(hwnd.0)) }
+                .ok()?;
+
+            let play_handle = app.clone();
+            let handler = TypedEventHandler::new(move |_, args: Option<_>| {
+                if let Some(args) = args {
+                    if let Ok(button) = args.Button() {
+                        match button {
+                            SystemMediaTransportControlsButton::Play => {
+                                emit_media_event(&play_handle, MEDIA_PLAY_EVENT);
+                            }
+                            SystemMediaTransportControlsButton::Pause => {
+                                emit_media_event(&play_handle, MEDIA_PAUSE_EVENT);
+                            }
+                            SystemMediaTransportControlsButton::PlayPause => {
+                                emit_media_event(&play_handle, MEDIA_PLAY_EVENT);
+                            }
+                            SystemMediaTransportControlsButton::Next => {
+                                emit_media_event(&play_handle, MEDIA_NEXT_EVENT);
+                            }
+                            SystemMediaTransportControlsButton::Previous => {
+                                emit_media_event(&play_handle, MEDIA_PREVIOUS_EVENT);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                Ok(())
+            });
+
+            smtc.SetIsEnabled(true).ok()?;
+            smtc.SetIsPlayEnabled(true).ok()?;
+            smtc.SetIsPauseEnabled(true).ok()?;
+            smtc.SetIsStopEnabled(true).ok()?;
+            smtc.SetIsNextEnabled(true).ok()?;
+            smtc.SetIsPreviousEnabled(true).ok()?;
+
+            let button_token = smtc.ButtonPressed(&handler).ok()?;
+
+            let property_handler = TypedEventHandler::new(move |_, _| Ok(()));
+            let property_token = smtc.PropertyChanged(&property_handler).ok()?;
+
+            Some(Self {
+                smtc,
+                _button_token: button_token,
+                _property_token: property_token,
+            })
+        }
+
+        pub fn update(&self, update: &MediaUpdate) {
+            let status = match update.playback {
+                PlaybackStatus::Playing => MediaPlaybackStatus::Playing,
+                PlaybackStatus::Paused => MediaPlaybackStatus::Paused,
+                PlaybackStatus::Stopped => MediaPlaybackStatus::Stopped,
+            };
+            if let Err(error) = self.smtc.SetPlaybackStatus(status) {
+                eprintln!("[soundcloud-wrapper] Failed to set SMTC status: {error:?}");
+            }
+
+            if let Some(metadata) = &update.metadata {
+                if let Err(error) = update_display(&self.smtc, metadata) {
+                    eprintln!("[soundcloud-wrapper] Failed to update SMTC metadata: {error:?}");
+                }
+            }
+        }
+    }
+
+    fn update_display(
+        smtc: &SystemMediaTransportControls,
+        metadata: &MediaMetadata,
+    ) -> windows::core::Result<()> {
+        let updater: SystemMediaTransportControlsDisplayUpdater = smtc.DisplayUpdater()?;
+        updater.SetType(MediaPlaybackType::Music)?;
+        let music = updater.MusicProperties()?;
+
+        if let Some(title) = &metadata.title {
+            music.SetTitle(&HSTRING::from(title))?;
+        }
+        if let Some(artist) = &metadata.artist {
+            music.SetArtist(&HSTRING::from(artist))?;
+        }
+        if let Some(album) = &metadata.album {
+            music.SetAlbumTitle(&HSTRING::from(album))?;
+        }
+
+        if let Some(art) = &metadata.artwork_url {
+            if let Ok(uri) = Uri::CreateUri(&HSTRING::from(art)) {
+                if let Ok(stream) = RandomAccessStreamReference::CreateFromUri(&uri) {
+                    updater.SetThumbnail(stream)?;
+                }
+            }
+        }
+
+        updater.Update()?;
+
+        let timeline = SystemMediaTransportControlsTimelineProperties::new()?;
+        timeline.SetStartTime(windows::Foundation::TimeSpan { Duration: 0 })?;
+        timeline.SetPosition(windows::Foundation::TimeSpan { Duration: 0 })?;
+        timeline.SetEndTime(windows::Foundation::TimeSpan { Duration: 0 })?;
+        smtc.UpdateTimelineProperties(timeline)?;
+
+        Ok(())
+    }
+
+    impl Drop for WindowsIntegration {
+        fn drop(&mut self) {
+            let _ = self.smtc.RemoveButtonPressed(self._button_token);
+            let _ = self.smtc.RemovePropertyChanged(self._property_token);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use objc2::rc::autoreleasepool;
+    use objc2::runtime::Class;
+    use objc2::{msg_send, sel, sel_impl};
+    use objc2_foundation::{ns_string, NSDictionary, NSNumber, NSString};
+
+    pub struct MacIntegration;
+
+    impl MacIntegration {
+        pub fn new() -> Option<Self> {
+            unsafe { Class::get("MPNowPlayingInfoCenter").map(|_| MacIntegration) }
+        }
+
+        pub fn update(&self, update: &MediaUpdate) {
+            autoreleasepool(|_| unsafe {
+                let Some(class) = Class::get("MPNowPlayingInfoCenter") else {
+                    return;
+                };
+                let center: *mut objc2::runtime::Object = msg_send![class, defaultCenter];
+                if center.is_null() {
+                    return;
+                }
+
+                let mut entries: Vec<(&NSString, &objc2::runtime::Object)> = Vec::new();
+
+                if let Some(metadata) = &update.metadata {
+                    if let Some(title) = &metadata.title {
+                        let value = NSString::from_str(title);
+                        entries.push((ns_string!("MPMediaItemPropertyTitle"), value.as_ref()));
+                    }
+                    if let Some(artist) = &metadata.artist {
+                        let value = NSString::from_str(artist);
+                        entries.push((ns_string!("MPMediaItemPropertyArtist"), value.as_ref()));
+                    }
+                    if let Some(album) = &metadata.album {
+                        let value = NSString::from_str(album);
+                        entries.push((ns_string!("MPMediaItemPropertyAlbumTitle"), value.as_ref()));
+                    }
+                    if let Some(artwork) = &metadata.artwork_url {
+                        let value = NSString::from_str(artwork);
+                        entries.push((ns_string!("MPNowPlayingInfoPropertyAssetURL"), value.as_ref()));
+                    }
+                }
+
+                let rate = match update.playback {
+                    PlaybackStatus::Playing => 1.0,
+                    _ => 0.0,
+                };
+                let rate_number = NSNumber::new_f64(rate);
+                entries.push((ns_string!("MPNowPlayingInfoPropertyPlaybackRate"), rate_number.as_ref()));
+
+                let (keys, values): (Vec<_>, Vec<_>) = entries.into_iter().unzip();
+                let dict = NSDictionary::from_slices(&keys, &values);
+                let _: () = msg_send![center, setNowPlayingInfo: dict];
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add optional Linux MPRIS, Windows SMTC, and macOS Now Playing integrations with shared media state management
- implement tray icon controls, theme-change notifications, and window lifecycle handling in the Tauri backend
- extend the injected web script to emit media metadata, react to theme updates, and respond to tray navigation requests

## Testing
- `cargo check` *(fails: requires glib/gobject development packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cada5ca3c0832594d6af7b456f0ae1