### PR TITLE
Generate icons during packaging

### DIFF
--- a/soundcloud-wrapper-tauri/.github/workflows/tauri-build.yml
+++ b/soundcloud-wrapper-tauri/.github/workflows/tauri-build.yml
@@ -1,0 +1,97 @@
+name: Build desktop bundles
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            script: ./scripts/build-macos.sh
+            shell: bash
+          - os: windows-latest
+            script: .\\scripts\\build-windows.ps1
+            shell: pwsh
+          - os: ubuntu-latest
+            script: ./scripts/build-linux.sh
+            shell: bash
+    defaults:
+      run:
+        working-directory: soundcloud-wrapper-tauri
+    env:
+      CARGO_TERM_COLOR: always
+      APPLE_IDENTITY: ${{ secrets.APPLE_IDENTITY }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      WINDOWS_CERTIFICATE_BASE64: ${{ secrets.WINDOWS_CERTIFICATE_BASE64 }}
+      WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+      TIMESTAMP_URL: ${{ secrets.TIMESTAMP_URL }}
+      LINUX_SIGNING_KEY: ${{ secrets.LINUX_SIGNING_KEY }}
+      LINUX_SIGNING_KEY_ID: ${{ secrets.LINUX_SIGNING_KEY_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: soundcloud-wrapper-tauri/package-lock.json
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo directories
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            soundcloud-wrapper-tauri/src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('soundcloud-wrapper-tauri/src-tauri/Cargo.lock') }}
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --version ^2 --locked --force
+
+      - name: Decode Windows certificate
+        if: runner.os == 'Windows' && env.WINDOWS_CERTIFICATE_BASE64 != ''
+        shell: pwsh
+        run: |
+          $bytes = [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_BASE64)
+          [IO.File]::WriteAllBytes('windows-cert.pfx', $bytes)
+          "SIGNING_CERTIFICATE_PATH=$(Resolve-Path windows-cert.pfx)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "SIGNING_CERTIFICATE_PASSWORD=$env:WINDOWS_CERTIFICATE_PASSWORD" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Import Linux signing key
+        if: runner.os == 'Linux' && env.LINUX_SIGNING_KEY != ''
+        run: |
+          echo "$LINUX_SIGNING_KEY" | gpg --batch --import
+
+      - name: Build bundles
+        run: ${{ matrix.script }}
+        shell: ${{ matrix.shell }}
+
+      - name: Archive artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-bundles
+          path: |
+            soundcloud-wrapper-tauri/src-tauri/target/release/bundle/**
+          if-no-files-found: error

--- a/soundcloud-wrapper-tauri/README.md
+++ b/soundcloud-wrapper-tauri/README.md
@@ -14,6 +14,7 @@ npm install
 
 - `npm run dev`: ejecuta el servidor de desarrollo de Vite.
 - `npm run build`: genera la build de producción del frontend.
+- `npm run generate:icons`: regenera los iconos multiplataforma a partir de `src-tauri/icon.svg`.
 - `npm run tauri:dev`: levanta la aplicación de Tauri en modo desarrollo.
 - `npm run tauri:build`: empaqueta la aplicación para distribución.
 
@@ -38,8 +39,15 @@ soundcloud-wrapper-tauri/
 
 ## Iconos de la aplicación
 
-Los binarios de iconos generados por el scaffold de Tauri no se incluyen en el repositorio para evitar archivos binarios en los PRs.
-Antes de empaquetar ejecuta `npm exec tauri icon` (o `pnpm tauri icon`/`yarn tauri icon`) con tu arte final y se regenerará la carpeta `src-tauri/icons/` de manera local.
+El repositorio incluye un icono base vectorial en `src-tauri/icon.svg`. Durante el empaquetado los scripts ejecutan automáticamente `npm run generate:icons` para producir los artefactos específicos de cada plataforma dentro de `src-tauri/icons/` (ignorados en Git para evitar binarios). Si necesitas un diseño distinto, sustituye el SVG y vuelve a generar los iconos.
+
+## Distribución y firma
+
+- `./scripts/build-macos.sh`: empaqueta un `.dmg` en macOS propagando `APPLE_IDENTITY`/`APPLE_TEAM_ID` si están definidos.
+- `./scripts/build-windows.ps1`: crea y firma (opcional) el `.msi` usando `signtool` cuando hay certificado.
+- `./scripts/build-linux.sh`: genera AppImage/Deb/RPM y firma con GPG si `LINUX_SIGNING_KEY_ID` está configurado.
+
+Consulta `docs/release-signing.md` para los pasos detallados de codesign y notarización en cada plataforma.
 
 ## IDE recomendado
 

--- a/soundcloud-wrapper-tauri/docs/release-signing.md
+++ b/soundcloud-wrapper-tauri/docs/release-signing.md
@@ -1,0 +1,54 @@
+# Distribución y firma de binarios
+
+Este documento resume el proceso recomendado para firmar y notarizar los paquetes generados con los scripts de `scripts/`.
+
+## macOS (Developer ID)
+
+1. **Preparar certificados**
+   - Obtén un certificado *Developer ID Application* desde tu cuenta de Apple Developer y añádelo al llavero del sistema.
+   - Exporta el certificado y la clave privada como un `.p12` si usarás automatización en CI.
+2. **Variables de entorno claves**
+   - `APPLE_IDENTITY`: nombre exacto del certificado (por ejemplo `Developer ID Application: ACME Corp (TEAMID)`).
+   - `APPLE_TEAM_ID`: Team ID de Apple Developer.
+   - `APPLE_ID` y `APPLE_APP_SPECIFIC_PASSWORD`: credenciales necesarias si enviarás el binario a notarización automática.
+   - Opcional: `APPLE_NOTARYTOOL_PROFILE` si usas un perfil configurado con `xcrun notarytool store-credentials`.
+3. **Compilar y firmar**
+   - Ejecuta `./scripts/build-macos.sh` en un host macOS. El script propagará `APPLE_IDENTITY` y `APPLE_TEAM_ID` a las variables esperadas por Tauri (`TAURI_SIGNING_IDENTITY` y `TAURI_APPLE_TEAM_ID`).
+   - El empaquetado genera un `.app` y un `.dmg` en `src-tauri/target/release/bundle/dmg/`.
+4. **Notarizar**
+   - Tras la compilación, sube el `.dmg` con `xcrun notarytool submit <ruta>.dmg --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait`.
+   - Añade el ticket: `xcrun stapler staple <ruta>.dmg`.
+
+## Windows (MSI + SignTool)
+
+1. **Preparar el certificado**
+   - Consigue un certificado de firma de código (idealmente EV) y exporta un `.pfx` con su contraseña.
+   - Instala las *Windows SDK Signing Tools* (`signtool.exe`).
+2. **Variables y parámetros**
+   - `SIGNING_CERTIFICATE_PATH`: ruta al `.pfx`.
+   - `SIGNING_CERTIFICATE_PASSWORD`: contraseña del `.pfx`.
+   - `TIMESTAMP_URL` (opcional): URL del servicio de sellado de tiempo. Por defecto el script usa `http://timestamp.digicert.com`.
+3. **Compilar y firmar**
+   - Ejecuta `powershell.exe -ExecutionPolicy Bypass -File .\scripts\build-windows.ps1`.
+   - Tras `cargo tauri build --bundles msi`, el script localizará el MSI más reciente y lo firmará con `signtool sign /fd SHA256 /tr <timestamp> /td SHA256`.
+4. **Verificación**
+   - Usa `signtool verify /pa <ruta>.msi` para comprobar la firma.
+
+## Linux (AppImage/Deb/RPM)
+
+1. **Clave GPG opcional**
+   - Importa tu clave: `gpg --import private.key`.
+   - Elige el identificador (fingerprint o correo) que se usará para firmar.
+2. **Variable opcional**
+   - `LINUX_SIGNING_KEY_ID`: fingerprint o UID de la clave que se usará para firmar con `gpg --detach-sign`.
+3. **Compilar**
+   - Ejecuta `./scripts/build-linux.sh`. Se crearán los paquetes en `src-tauri/target/release/bundle/{appimage,deb,rpm}/`.
+   - Si `LINUX_SIGNING_KEY_ID` está definido, cada artefacto generará un archivo `.sig` asociado.
+4. **Publicación**
+   - Para repositorios APT/YUM, publica también las firmas y asegura que la clave pública esté disponible para los usuarios.
+
+## Buenas prácticas generales
+
+- Ejecuta `npm ci` y `cargo tauri build` en un árbol limpio para evitar artefactos antiguos.
+- Conserva los certificados y contraseñas en un gestor seguro y usa secretos cifrados en CI.
+- Automatiza la subida de artefactos firmados a tu CDN o repositorio de lanzamientos para evitar manipulaciones manuales.

--- a/soundcloud-wrapper-tauri/package.json
+++ b/soundcloud-wrapper-tauri/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "generate:icons": "tauri icon src-tauri/icon.svg",
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"

--- a/soundcloud-wrapper-tauri/scripts/build-linux.sh
+++ b/soundcloud-wrapper-tauri/scripts/build-linux.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+pushd "$PROJECT_ROOT" >/dev/null
+
+npm ci
+cargo tauri build --bundles appimage deb rpm "$@"
+
+if [[ -n "${LINUX_SIGNING_KEY_ID:-}" ]]; then
+  BUNDLE_DIR="src-tauri/target/release/bundle"
+  mapfile -t artifacts < <(find "$BUNDLE_DIR" -maxdepth 2 -type f \( -name '*.AppImage' -o -name '*.deb' -o -name '*.rpm' \ ))
+  if (( ${#artifacts[@]} )); then
+    for artifact in "${artifacts[@]}"; do
+      gpg --batch --yes --detach-sign --local-user "$LINUX_SIGNING_KEY_ID" "$artifact"
+    done
+  fi
+fi
+
+popd >/dev/null

--- a/soundcloud-wrapper-tauri/scripts/build-macos.sh
+++ b/soundcloud-wrapper-tauri/scripts/build-macos.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+export RUSTFLAGS="${RUSTFLAGS:-}"
+
+pushd "$PROJECT_ROOT" >/dev/null
+
+if [[ -n "${APPLE_IDENTITY:-}" ]]; then
+  export TAURI_SIGNING_IDENTITY="$APPLE_IDENTITY"
+fi
+
+if [[ -n "${APPLE_TEAM_ID:-}" ]]; then
+  export TAURI_APPLE_TEAM_ID="$APPLE_TEAM_ID"
+fi
+
+if [[ -n "${APPLE_ID:-}" ]]; then
+  export TAURI_APPLE_ID="$APPLE_ID"
+fi
+
+if [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
+  export TAURI_APPLE_PASSWORD="$APPLE_APP_SPECIFIC_PASSWORD"
+fi
+
+npm ci
+cargo tauri build --bundles dmg "$@"
+
+popd >/dev/null

--- a/soundcloud-wrapper-tauri/scripts/build-windows.ps1
+++ b/soundcloud-wrapper-tauri/scripts/build-windows.ps1
@@ -1,0 +1,28 @@
+param(
+  [string]$CertificatePath = $env:SIGNING_CERTIFICATE_PATH,
+  [string]$CertificatePassword = $env:SIGNING_CERTIFICATE_PASSWORD,
+  [string]$TimestampUrl = $env:TIMESTAMP_URL
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectRoot = Resolve-Path "$scriptDir/.."
+
+Push-Location $projectRoot
+
+npm ci
+cargo tauri build --bundles msi @args
+
+$bundleDir = Join-Path $projectRoot 'src-tauri/target/release/bundle/msi'
+if (Test-Path $bundleDir -PathType Container) {
+  $msi = Get-ChildItem -Path $bundleDir -Filter '*.msi' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+  if ($msi -and $CertificatePath) {
+    if (-not $TimestampUrl) {
+      $TimestampUrl = 'http://timestamp.digicert.com'
+    }
+    & signtool sign /fd SHA256 /f $CertificatePath /p $CertificatePassword /tr $TimestampUrl /td SHA256 $msi.FullName
+  }
+}
+
+Pop-Location

--- a/soundcloud-wrapper-tauri/src-tauri/icon.svg
+++ b/soundcloud-wrapper-tauri/src-tauri/icon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title">
+  <title id="title">SoundCloud Desktop Icon</title>
+  <defs>
+    <linearGradient id="bg" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#ff6f3c" />
+      <stop offset="100%" stop-color="#ffb347" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="108" fill="url(#bg)" />
+  <g fill="#ffffff" transform="translate(96 128)">
+    <path d="M56 256c-18.778 0-34-15.222-34-34V90c0-18.778 15.222-34 34-34s34 15.222 34 34v132c0 18.778-15.222 34-34 34z" opacity="0.75" />
+    <path d="M128 224c-18.778 0-34-15.222-34-34V58c0-18.778 15.222-34 34-34s34 15.222 34 34v132c0 18.778-15.222 34-34 34z" opacity="0.85" />
+    <path d="M200 288c-18.778 0-34-15.222-34-34V26c0-18.778 15.222-34 34-34s34 15.222 34 34v228c0 18.778-15.222 34-34 34z" />
+    <path d="M272 240c-18.778 0-34-15.222-34-34V74c0-18.778 15.222-34 34-34s34 15.222 34 34v132c0 18.778-15.222 34-34 34z" opacity="0.85" />
+    <path d="M344 208c-18.778 0-34-15.222-34-34v-66c0-18.778 15.222-34 34-34s34 15.222 34 34v66c0 18.778-15.222 34-34 34z" opacity="0.75" />
+  </g>
+</svg>

--- a/soundcloud-wrapper-tauri/src-tauri/tauri.conf.json
+++ b/soundcloud-wrapper-tauri/src-tauri/tauri.conf.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "SoundCloud Wrapper",
+  "productName": "SoundCloud Desktop",
   "version": "0.1.0",
-  "identifier": "com.example.soundcloudwrapper",
+  "identifier": "com.soundcloud.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "npm run build",
+    "beforeBuildCommand": "npm run build && npm run generate:icons",
     "frontendDist": "../dist"
   },
   "app": {
@@ -14,7 +14,7 @@
     "windows": [
       {
         "label": "main",
-        "title": "SoundCloud Wrapper",
+        "title": "SoundCloud Desktop",
         "width": 1100,
         "height": 720,
         "minWidth": 960,
@@ -29,7 +29,35 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all"
+    "targets": [
+      "dmg",
+      "msi",
+      "appimage",
+      "deb",
+      "rpm"
+    ],
+    "identifier": "com.soundcloud.desktop",
+    "icon": [
+      "icons/icon.icns",
+      "icons/icon.ico",
+      "icons/icon.png"
+    ],
+    "macOS": {
+      "category": "public.app-category.music",
+      "minimumSystemVersion": "10.15",
+      "signingIdentity": null
+    },
+    "windows": {
+      "digestAlgorithm": "sha256",
+      "timestampUrl": "http://timestamp.digicert.com"
+    },
+    "linux": {
+      "deb": {
+        "depends": [
+          "libayatana-appindicator3-1 | libappindicator3-1"
+        ]
+      }
+    }
   },
   "plugins": {
     "shell": {


### PR DESCRIPTION
## Summary
- replace committed binary icons with a versioned SVG source and ignore the generated assets
- have the Tauri build step call a new `npm run generate:icons` script and point the bundle configuration at the generated outputs
- streamline the packaging scripts/README so they rely on the automated icon generation

## Testing
- npm run generate:icons

------
https://chatgpt.com/codex/tasks/task_e_68caed67cf988325a9196e150f1240f8