### PR TITLE
Add Rekordbox import pipeline with background refresh

### DIFF
--- a/soundcloud-wrapper-tauri/src-tauri/Cargo.lock
+++ b/soundcloud-wrapper-tauri/src-tauri/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +947,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fallible-iterator"
@@ -2996,6 +3008,16 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
@@ -3694,9 +3716,12 @@ dependencies = [
  "mpris-player",
  "objc2 0.6.2",
  "objc2-foundation 0.3.1",
+ "quick-xml 0.30.0",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
+ "symphonia",
  "tauri",
  "tauri-build",
  "tauri-plugin-global-shortcut",
@@ -3784,6 +3809,140 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-flac",
+ "symphonia-bundle-mp3",
+ "symphonia-codec-aac",
+ "symphonia-codec-alac",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e34f34298a7308d4397a6c7fbf5b84c5d491231ce3dd379707ba673ab3bd97"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01c2aae70f0f1fb096b6f0ff112a930b1fb3626178fba3ae68b09dce71706d4"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbf25b545ad0d3ee3e891ea643ad115aff4ca92f6aec472086b957a58522f70"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d8a6666649a08412906476a8b0efd9b9733e241180189e9f92b09c08d0e38f3"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a98765fb46a0a6732b007f7e2870c2129b6f78d87db7987e6533c8f164a9f30"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abfdf178d697e50ce1e5d9b982ba1b94c47218e03ec35022d9f0e071a16dc844"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f7be232f962f937f4b7115cbe62c330929345434c834359425e043bfd15f50"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "484472580fa49991afda5f6550ece662237b00c6f562c7d9638d1b086ed010fe"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
 ]
 
 [[package]]

--- a/soundcloud-wrapper-tauri/src-tauri/Cargo.toml
+++ b/soundcloud-wrapper-tauri/src-tauri/Cargo.toml
@@ -30,6 +30,17 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2"
 rusqlite = { version = "0.30", features = ["bundled"] }
+quick-xml = { version = "0.30", features = ["serialize"] }
+sha2 = "0.10"
+symphonia = { version = "0.5", default-features = false, features = [
+    "aac",
+    "alac",
+    "flac",
+    "isomp4",
+    "mp3",
+    "vorbis",
+    "wav",
+] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glib = { version = "0.15", features = ["v2_58"], optional = true }

--- a/soundcloud-wrapper-tauri/src-tauri/src/rekordbox.rs
+++ b/soundcloud-wrapper-tauri/src-tauri/src/rekordbox.rs
@@ -1,0 +1,463 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+
+use quick_xml::de::from_reader as from_xml_reader;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use symphonia::core::codecs::DecoderOptions;
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::{FormatOptions, FormatReader};
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RekordboxCue {
+    pub slot: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    pub position_ms: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cue_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RekordboxTrack {
+    pub rekordbox_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub track_reference: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artist: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub normalized_path: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checksum: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    pub available: bool,
+    pub cues: Vec<RekordboxCue>,
+}
+
+#[derive(Debug)]
+pub enum RekordboxError {
+    Io(std::io::Error),
+    Database(rusqlite::Error),
+    Xml(quick_xml::DeError),
+    Audio(SymphoniaError),
+}
+
+impl fmt::Display for RekordboxError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RekordboxError::Io(error) => write!(f, "filesystem error: {error}"),
+            RekordboxError::Database(error) => write!(f, "sqlite error: {error}"),
+            RekordboxError::Xml(error) => write!(f, "xml error: {error}"),
+            RekordboxError::Audio(error) => write!(f, "audio probe error: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for RekordboxError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RekordboxError::Io(error) => Some(error),
+            RekordboxError::Database(error) => Some(error),
+            RekordboxError::Xml(error) => Some(error),
+            RekordboxError::Audio(error) => Some(error),
+        }
+    }
+}
+
+impl From<std::io::Error> for RekordboxError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<rusqlite::Error> for RekordboxError {
+    fn from(value: rusqlite::Error) -> Self {
+        Self::Database(value)
+    }
+}
+
+impl From<quick_xml::DeError> for RekordboxError {
+    fn from(value: quick_xml::DeError) -> Self {
+        Self::Xml(value)
+    }
+}
+
+impl From<SymphoniaError> for RekordboxError {
+    fn from(value: SymphoniaError) -> Self {
+        Self::Audio(value)
+    }
+}
+
+pub fn load_tracks(path: &Path) -> Result<Vec<RekordboxTrack>, RekordboxError> {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("xml"))
+    {
+        Some(true) => parse_xml_export(path),
+        _ => parse_master_db(path),
+    }
+}
+
+pub fn supports_auto_refresh(path: &Path) -> bool {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some(ext) if ext.eq_ignore_ascii_case("xml") => false,
+        _ => true,
+    }
+}
+
+fn parse_master_db(path: &Path) -> Result<Vec<RekordboxTrack>, RekordboxError> {
+    let connection = Connection::open(path)?;
+    let mut cue_statement =
+        connection.prepare("SELECT SongID, HotCueNo, InMsec, Name, Color, Type FROM djmdHotCue")?;
+
+    let mut cue_rows = cue_statement.query([])?;
+    let mut cue_map: HashMap<i64, Vec<RekordboxCue>> = HashMap::new();
+
+    while let Some(row) = cue_rows.next()? {
+        let song_id: i64 = row.get(0)?;
+        let slot: i64 = row.get(1)?;
+        let position: i64 = row.get::<_, Option<i64>>(2)?.unwrap_or_default();
+        let name: Option<String> = row.get(3)?;
+        let color: Option<String> = row.get(4)?;
+        let cue_type: Option<String> = row.get(5)?;
+
+        cue_map.entry(song_id).or_default().push(RekordboxCue {
+            slot,
+            name,
+            color,
+            position_ms: position,
+            cue_type,
+        });
+    }
+
+    let mut statement = connection.prepare(
+        "SELECT ID, TrackID, Title, Artist, Album, FilePath, FolderPath, FileName FROM djmdSong",
+    )?;
+
+    let mut rows = statement.query([])?;
+    let mut tracks = Vec::new();
+
+    while let Some(row) = rows.next()? {
+        let rekordbox_id: i64 = row.get(0)?;
+        let rekordbox_id_str = rekordbox_id.to_string();
+        let track_reference: Option<String> = row.get(1)?;
+        let title: Option<String> = row.get(2)?;
+        let artist: Option<String> = row.get(3)?;
+        let album: Option<String> = row.get(4)?;
+        let file_path_value: Option<String> = row.get(5)?;
+        let folder_path: Option<String> = row.get(6)?;
+        let file_name: Option<String> = row.get(7)?;
+
+        let location = resolve_location(&file_path_value, &folder_path, &file_name);
+        let normalized_path = location.as_ref().and_then(|value| decode_location(value));
+
+        let metadata = normalized_path
+            .as_ref()
+            .and_then(|path| match compute_file_metadata(path) {
+                Ok(metadata) => Some(metadata),
+                Err(error) => {
+                    eprintln!(
+                        "failed to compute metadata for rekordbox entry {rekordbox_id_str}: {error}"
+                    );
+                    None
+                }
+            })
+            .unwrap_or_else(FileMetadata::missing);
+
+        tracks.push(RekordboxTrack {
+            rekordbox_id: rekordbox_id_str,
+            track_reference,
+            title,
+            artist,
+            album,
+            location,
+            normalized_path,
+            checksum: metadata.checksum,
+            duration_ms: metadata.duration_ms,
+            available: metadata.available,
+            cues: cue_map.remove(&rekordbox_id).unwrap_or_default(),
+        });
+    }
+
+    Ok(tracks)
+}
+
+#[derive(Debug, Deserialize)]
+struct XmlRoot {
+    #[serde(rename = "COLLECTION")]
+    collection: Option<XmlCollection>,
+}
+
+#[derive(Debug, Deserialize)]
+struct XmlCollection {
+    #[serde(rename = "TRACK", default)]
+    tracks: Vec<XmlTrack>,
+}
+
+#[derive(Debug, Deserialize)]
+struct XmlTrack {
+    #[serde(rename = "@TrackID")]
+    track_id: Option<String>,
+    #[serde(rename = "@Name")]
+    name: Option<String>,
+    #[serde(rename = "@Artist")]
+    artist: Option<String>,
+    #[serde(rename = "@Album")]
+    album: Option<String>,
+    #[serde(rename = "@Location")]
+    location: Option<String>,
+    #[serde(rename = "@RekordboxID")]
+    rekordbox_id: Option<String>,
+    #[serde(rename = "POSITION_MARK", default)]
+    position_marks: Vec<XmlCue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct XmlCue {
+    #[serde(rename = "@Num")]
+    slot: Option<i64>,
+    #[serde(rename = "@Name")]
+    name: Option<String>,
+    #[serde(rename = "@Color")]
+    color: Option<String>,
+    #[serde(rename = "@Type")]
+    cue_type: Option<String>,
+    #[serde(rename = "@Start")]
+    start: Option<f64>,
+}
+
+fn parse_xml_export(path: &Path) -> Result<Vec<RekordboxTrack>, RekordboxError> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let root: XmlRoot = from_xml_reader(reader)?;
+    let collection = match root.collection {
+        Some(collection) => collection,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut result = Vec::new();
+
+    for entry in collection.tracks {
+        let rekordbox_id = match entry
+            .rekordbox_id
+            .clone()
+            .or_else(|| entry.track_id.clone())
+        {
+            Some(id) => id,
+            None => {
+                eprintln!(
+                    "skipping rekordbox XML track without an identifier: {:?}",
+                    entry.name
+                );
+                continue;
+            }
+        };
+
+        let normalized_path = entry
+            .location
+            .as_ref()
+            .and_then(|value| decode_location(value));
+
+        let metadata = normalized_path
+            .as_ref()
+            .and_then(|path| match compute_file_metadata(path) {
+                Ok(metadata) => Some(metadata),
+                Err(error) => {
+                    eprintln!(
+                        "failed to compute metadata for rekordbox entry {rekordbox_id}: {error}"
+                    );
+                    None
+                }
+            })
+            .unwrap_or_else(FileMetadata::missing);
+
+        let cues = entry
+            .position_marks
+            .into_iter()
+            .map(|cue| RekordboxCue {
+                slot: cue.slot.unwrap_or_default(),
+                name: cue.name,
+                color: cue.color,
+                position_ms: cue
+                    .start
+                    .map(|value| (value * 1000.0) as i64)
+                    .unwrap_or_default(),
+                cue_type: cue.cue_type,
+            })
+            .collect();
+
+        result.push(RekordboxTrack {
+            rekordbox_id,
+            track_reference: entry.track_id,
+            title: entry.name,
+            artist: entry.artist,
+            album: entry.album,
+            location: entry.location.clone(),
+            normalized_path,
+            checksum: metadata.checksum,
+            duration_ms: metadata.duration_ms,
+            available: metadata.available,
+            cues,
+        });
+    }
+
+    Ok(result)
+}
+
+fn resolve_location(
+    file_path: &Option<String>,
+    folder_path: &Option<String>,
+    file_name: &Option<String>,
+) -> Option<String> {
+    if let Some(path) = file_path.clone() {
+        if !path.is_empty() {
+            return Some(path);
+        }
+    }
+
+    match (folder_path, file_name) {
+        (Some(folder), Some(name)) => {
+            if folder.ends_with('/') {
+                Some(format!("{folder}{name}"))
+            } else {
+                Some(format!("{folder}/{name}"))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn decode_location(value: &str) -> Option<PathBuf> {
+    if value.starts_with("file://") {
+        if let Ok(url) = url::Url::parse(value) {
+            if url.scheme() == "file" {
+                return url.to_file_path().ok();
+            }
+        }
+    }
+
+    Some(PathBuf::from(value))
+}
+
+struct FileMetadata {
+    checksum: Option<String>,
+    duration_ms: Option<u64>,
+    available: bool,
+}
+
+impl FileMetadata {
+    fn missing() -> Self {
+        Self {
+            checksum: None,
+            duration_ms: None,
+            available: false,
+        }
+    }
+}
+
+fn compute_file_metadata(path: &Path) -> Result<FileMetadata, RekordboxError> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(FileMetadata::missing());
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let bytes = reader.read(&mut buffer)?;
+        if bytes == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes]);
+    }
+
+    let checksum = format!("{:x}", hasher.finalize());
+
+    let duration_ms = compute_duration(path).unwrap_or(None);
+
+    Ok(FileMetadata {
+        checksum: Some(checksum),
+        duration_ms,
+        available: true,
+    })
+}
+
+fn compute_duration(path: &Path) -> Result<Option<u64>, RekordboxError> {
+    let file = File::open(path)?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(extension) = path.extension().and_then(|ext| ext.to_str()) {
+        hint.with_extension(extension);
+    }
+
+    let format_opts = FormatOptions::default();
+    let metadata_opts = MetadataOptions::default();
+    let probed =
+        symphonia::default::get_probe().format(&hint, mss, &format_opts, &metadata_opts)?;
+
+    let mut format = probed.format;
+
+    let track = format
+        .default_track()
+        .ok_or_else(|| SymphoniaError::ResetRequired)?;
+
+    let decoder_opts = DecoderOptions::default();
+    let mut decoder = symphonia::default::get_codecs().make(&track.codec_params, &decoder_opts)?;
+    let mut duration = 0u64;
+    let mut sample_rate = track.codec_params.sample_rate;
+
+    loop {
+        match format.next_packet() {
+            Ok(packet) => {
+                let decoded = decoder.decode(&packet)?;
+                if sample_rate.is_none() {
+                    sample_rate = Some(decoded.spec().rate);
+                }
+                let frames = decoded.frames();
+                duration += frames as u64;
+            }
+            Err(SymphoniaError::IoError(ref error))
+                if error.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                break;
+            }
+            Err(SymphoniaError::ResetRequired) => {
+                break;
+            }
+            Err(err) => return Err(RekordboxError::Audio(err)),
+        }
+    }
+
+    let sample_rate = match sample_rate {
+        Some(rate) if rate > 0 => rate,
+        _ => return Ok(None),
+    };
+
+    if sample_rate == 0 {
+        return Ok(None);
+    }
+
+    let seconds = duration as f64 / sample_rate as f64;
+    Ok(Some((seconds * 1000.0) as u64))
+}


### PR DESCRIPTION
## Summary
- add Rekordbox ingestion helpers for both the SQLite `master.db` and XML exports, including local file metadata hashing and cue extraction
- extend the library store schema to track Rekordbox mappings, local asset durations, and synchronize records based on Rekordbox IDs
- expose an `import_rekordbox_library` command that can trigger optional background refreshes when the Rekordbox database changes

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml *(fails: missing system dependency `glib-2.0` for pkg-config)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9ee919fc8325a13c5d33deccafca