### PR TITLE
Handle SoundCloud library sync events

### DIFF
--- a/soundcloud-wrapper-tauri/src-tauri/src/library/mod.rs
+++ b/soundcloud-wrapper-tauri/src-tauri/src/library/mod.rs
@@ -241,6 +241,16 @@ impl LibraryStore {
         Ok(())
     }
 
+    pub fn sync_soundcloud_track(
+        &self,
+        track: &TrackRecord,
+        source: &SoundcloudSourceRecord,
+    ) -> Result<(), LibraryError> {
+        self.upsert_track(track)?;
+        self.link_soundcloud_source(source)?;
+        Ok(())
+    }
+
     pub fn record_local_asset(&self, record: &LocalAssetRecord) -> Result<(), LibraryError> {
         self.ensure_track(&record.track_id)?;
         self.connection.execute(


### PR DESCRIPTION
## Summary
- add injected script interceptors that normalize SoundCloud like and playlist data, deduplicate events, and emit refreshable updates to the backend
- extend the Tauri backend with SoundCloud payload parsing, new IPC handlers, and a refresh command that populates the library store
- add a library store helper to upsert SoundCloud track metadata alongside source payloads

## Testing
- npm run test *(fails: QA plan markdown missing required sections)*

------
https://chatgpt.com/codex/tasks/task_e_68dda9db791c8325ab662a18f6363253