### PR TITLE
Add Discogs integration and lookup worker

### DIFF
--- a/soundcloud-wrapper-tauri/src-tauri/Cargo.lock
+++ b/soundcloud-wrapper-tauri/src-tauri/Cargo.lock
@@ -541,6 +541,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -562,7 +572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -575,7 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.9.4",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -855,7 +865,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.6",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1535,6 +1545,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.11.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1632,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -1614,12 +1654,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1630,8 +1681,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1640,6 +1691,36 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1651,8 +1732,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1660,6 +1741,20 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1673,14 +1768,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3236,6 +3331,47 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
@@ -3244,10 +3380,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -3256,7 +3392,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower",
@@ -3267,6 +3403,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3309,6 +3459,37 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3388,6 +3569,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "selectors"
@@ -3678,6 +3869,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -3717,6 +3918,7 @@ dependencies = [
  "objc2 0.6.2",
  "objc2-foundation 0.3.1",
  "quick-xml 0.30.0",
+ "reqwest 0.11.27",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3727,6 +3929,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
+ "tokio",
  "url",
  "windows",
 ]
@@ -3969,6 +4172,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -3985,6 +4194,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4008,7 +4238,7 @@ checksum = "959469667dbcea91e5485fc48ba7dd6023face91bb0f1a14681a70f99847c3f7"
 dependencies = [
  "bitflags 2.9.4",
  "block2 0.6.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -4073,7 +4303,7 @@ dependencies = [
  "glob",
  "gtk",
  "heck 0.5.0",
- "http",
+ "http 1.3.1",
  "jni",
  "libc",
  "log",
@@ -4087,7 +4317,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4253,7 +4483,7 @@ dependencies = [
  "cookie",
  "dpi",
  "gtk",
- "http",
+ "http 1.3.1",
  "jni",
  "objc2 0.6.2",
  "objc2-ui-kit",
@@ -4276,7 +4506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fe9d48bd122ff002064e88cfcd7027090d789c4302714e68fcccba0f4b7807"
 dependencies = [
  "gtk",
- "http",
+ "http 1.3.1",
  "jni",
  "log",
  "objc2 0.6.2",
@@ -4309,7 +4539,7 @@ dependencies = [
  "dunce",
  "glob",
  "html5ever",
- "http",
+ "http 1.3.1",
  "infer",
  "json-patch",
  "kuchikiki",
@@ -4473,8 +4703,18 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4595,7 +4835,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -4610,8 +4850,8 @@ dependencies = [
  "bitflags 2.9.4",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -4765,6 +5005,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -5041,6 +5287,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "webview2-com"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5272,6 +5524,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -5310,6 +5580,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5371,6 +5656,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5389,6 +5680,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5404,6 +5701,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5437,6 +5740,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5452,6 +5761,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5473,6 +5788,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5488,6 +5809,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5517,6 +5844,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5557,7 +5894,7 @@ dependencies = [
  "gdkx11",
  "gtk",
  "html5ever",
- "http",
+ "http 1.3.1",
  "javascriptcore-rs",
  "jni",
  "kuchikiki",

--- a/soundcloud-wrapper-tauri/src-tauri/Cargo.toml
+++ b/soundcloud-wrapper-tauri/src-tauri/Cargo.toml
@@ -41,6 +41,8 @@ symphonia = { version = "0.5", default-features = false, features = [
     "vorbis",
     "wav",
 ] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+tokio = { version = "1", features = ["sync", "time"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glib = { version = "0.15", features = ["v2_58"], optional = true }

--- a/soundcloud-wrapper-tauri/src-tauri/src/discogs.rs
+++ b/soundcloud-wrapper-tauri/src-tauri/src/discogs.rs
@@ -1,0 +1,320 @@
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tauri::async_runtime;
+use tauri::AppHandle;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use crate::library::LibraryStore;
+use crate::SoundcloudTrackPayload;
+
+const SEARCH_URL: &str = "https://api.discogs.com/database/search";
+const DISCOGS_AMBIGUITY_EVENT: &str = "app://discogs/lookup-ambiguous";
+const USER_AGENT: &str = "SoundCloudWrapper/0.1 (+https://github.com/your-org/desktop-soundcloud)";
+
+#[derive(Clone)]
+pub struct DiscogsService {
+    sender: mpsc::Sender<SoundcloudTrackPayload>,
+}
+
+impl DiscogsService {
+    pub fn new(app: &AppHandle, library: Arc<Mutex<LibraryStore>>) -> Self {
+        let (sender, mut receiver) = mpsc::channel(32);
+        let client = Client::builder()
+            .user_agent(USER_AGENT)
+            .build()
+            .expect("failed to build Discogs client");
+        let app_handle = app.clone();
+        async_runtime::spawn(async move {
+            let mut rate_limiter = RateLimiter::new(Duration::from_millis(1100));
+            while let Some(payload) = receiver.recv().await {
+                if payload.track_id.is_empty() {
+                    continue;
+                }
+                process_job(
+                    &app_handle,
+                    Arc::clone(&library),
+                    &client,
+                    &mut rate_limiter,
+                    payload,
+                )
+                .await;
+            }
+        });
+
+        Self { sender }
+    }
+
+    pub fn queue_lookup(&self, payload: SoundcloudTrackPayload) {
+        let mut sender = self.sender.clone();
+        async_runtime::spawn(async move {
+            if let Err(error) = sender.send(payload).await {
+                eprintln!("[discogs] failed to enqueue lookup: {error}");
+            }
+        });
+    }
+}
+
+struct RateLimiter {
+    last: Option<Instant>,
+    interval: Duration,
+}
+
+impl RateLimiter {
+    fn new(interval: Duration) -> Self {
+        Self {
+            last: None,
+            interval,
+        }
+    }
+
+    async fn wait(&mut self) {
+        if let Some(last) = self.last {
+            let elapsed = last.elapsed();
+            if elapsed < self.interval {
+                sleep(self.interval - elapsed).await;
+            }
+        }
+        self.last = Some(Instant::now());
+    }
+}
+
+async fn process_job(
+    app: &AppHandle,
+    library: Arc<Mutex<LibraryStore>>,
+    client: &Client,
+    rate_limiter: &mut RateLimiter,
+    payload: SoundcloudTrackPayload,
+) {
+    let track_id = payload.track_id.clone();
+    let query = build_search_term(&payload);
+
+    if query.trim().is_empty() {
+        if let Ok(store) = library.lock() {
+            if let Err(error) =
+                store.record_discogs_failure(&track_id, &query, "missing title or artist")
+            {
+                eprintln!("[discogs] failed to persist lookup failure for {track_id}: {error}");
+            }
+        }
+        return;
+    }
+
+    match perform_lookup(client, rate_limiter, &payload, &query).await {
+        Ok(LookupResult::Success {
+            release,
+            confidence,
+        }) => {
+            if let Ok(store) = library.lock() {
+                if let Err(error) =
+                    store.record_discogs_success(&track_id, &query, &release, confidence)
+                {
+                    eprintln!("[discogs] failed to persist lookup success for {track_id}: {error}");
+                }
+            }
+        }
+        Ok(LookupResult::Ambiguous { candidates }) => {
+            if let Ok(store) = library.lock() {
+                if let Err(error) = store.record_discogs_ambiguity(&track_id, &query, &candidates) {
+                    eprintln!(
+                        "[discogs] failed to persist lookup ambiguity for {track_id}: {error}"
+                    );
+                }
+            }
+
+            if let Err(error) = app.emit_all(
+                DISCOGS_AMBIGUITY_EVENT,
+                json!({
+                    "trackId": track_id,
+                    "query": query,
+                    "candidates": candidates,
+                }),
+            ) {
+                eprintln!("[discogs] failed to emit ambiguity event: {error}");
+            }
+        }
+        Err(failure) => {
+            if let Ok(store) = library.lock() {
+                if let Err(error) =
+                    store.record_discogs_failure(&track_id, &query, &failure.into_message())
+                {
+                    eprintln!("[discogs] failed to persist lookup failure for {track_id}: {error}");
+                }
+            }
+        }
+    }
+}
+
+enum LookupResult {
+    Success { release: Value, confidence: f32 },
+    Ambiguous { candidates: Vec<Value> },
+}
+
+enum LookupFailure {
+    Message(String),
+    Error(String),
+}
+
+impl LookupFailure {
+    fn into_message(self) -> String {
+        match self {
+            LookupFailure::Message(message) => message,
+            LookupFailure::Error(error) => error,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct SearchResponse {
+    results: Vec<SearchResult>,
+}
+
+#[derive(Clone, Deserialize)]
+struct SearchResult {
+    id: Option<u64>,
+    title: Option<String>,
+    #[serde(rename = "type")]
+    result_type: Option<String>,
+    resource_url: Option<String>,
+    score: Option<f32>,
+    year: Option<u32>,
+    country: Option<String>,
+    thumb: Option<String>,
+}
+
+fn build_search_term(payload: &SoundcloudTrackPayload) -> String {
+    let mut terms = Vec::new();
+    if let Some(artist) = payload.artist.as_ref() {
+        if !artist.trim().is_empty() {
+            terms.push(artist.trim().to_string());
+        }
+    }
+    if let Some(title) = payload.title.as_ref() {
+        if !title.trim().is_empty() {
+            terms.push(title.trim().to_string());
+        }
+    }
+    terms.join(" ")
+}
+
+async fn perform_lookup(
+    client: &Client,
+    rate_limiter: &mut RateLimiter,
+    payload: &SoundcloudTrackPayload,
+    query: &str,
+) -> Result<LookupResult, LookupFailure> {
+    let mut params = vec![
+        ("type", "release".to_string()),
+        ("per_page", "5".to_string()),
+    ];
+
+    if let Some(artist) = payload.artist.as_ref() {
+        params.push(("artist", artist.clone()));
+    }
+    if let Some(title) = payload.title.as_ref() {
+        params.push(("release_title", title.clone()));
+    }
+    if !query.is_empty() {
+        params.push(("q", query.to_string()));
+    }
+
+    rate_limiter.wait().await;
+    let response = client
+        .get(SEARCH_URL)
+        .query(&params)
+        .send()
+        .await
+        .map_err(|error| LookupFailure::Error(error.to_string()))?;
+
+    if !response.status().is_success() {
+        return Err(LookupFailure::Message(format!(
+            "search returned status {}",
+            response.status()
+        )));
+    }
+
+    let body = response
+        .json::<SearchResponse>()
+        .await
+        .map_err(|error| LookupFailure::Error(error.to_string()))?;
+
+    let mut results: Vec<SearchResult> = body
+        .results
+        .into_iter()
+        .filter(|result| {
+            matches!(result.result_type.as_deref(), Some("release"))
+                && result.resource_url.is_some()
+        })
+        .collect();
+
+    if results.is_empty() {
+        return Err(LookupFailure::Message("no releases found".to_string()));
+    }
+
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let top_score = results
+        .first()
+        .and_then(|result| result.score)
+        .unwrap_or(0.0);
+    let second_score = results
+        .get(1)
+        .and_then(|result| result.score)
+        .unwrap_or(0.0);
+
+    if results.len() == 1 || (top_score >= 85.0 && top_score - second_score >= 10.0) {
+        let top = results.first().cloned().unwrap();
+        let release_url = top.resource_url.unwrap_or_else(|| {
+            top.id
+                .map(|id| format!("https://api.discogs.com/releases/{id}"))
+                .unwrap_or_default()
+        });
+
+        if release_url.is_empty() {
+            return Err(LookupFailure::Message(
+                "top result missing release URL".to_string(),
+            ));
+        }
+
+        rate_limiter.wait().await;
+        let release = client
+            .get(release_url)
+            .send()
+            .await
+            .map_err(|error| LookupFailure::Error(error.to_string()))?
+            .json::<Value>()
+            .await
+            .map_err(|error| LookupFailure::Error(error.to_string()))?;
+
+        return Ok(LookupResult::Success {
+            release,
+            confidence: top_score,
+        });
+    }
+
+    let candidates = results
+        .into_iter()
+        .take(5)
+        .map(|result| {
+            json!({
+                "id": result.id,
+                "title": result.title,
+                "score": result.score,
+                "year": result.year,
+                "country": result.country,
+                "resourceUrl": result.resource_url,
+                "thumb": result.thumb,
+            })
+        })
+        .collect();
+
+    Ok(LookupResult::Ambiguous { candidates })
+}


### PR DESCRIPTION
## Summary
- add a Discogs client module with a rate-limited worker queue that resolves releases and emits ambiguity events
- persist Discogs lookup outcomes through new LibraryStore helpers and trigger lookups from SoundCloud sync listeners
- include the required async HTTP dependencies for the new worker

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: missing system glib dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb96cdad0832580f82d7b5a8c61c2