### PR TITLE
Refactor Discogs metadata storage

### DIFF
--- a/soundcloud-wrapper-tauri/src-tauri/src/lib.rs
+++ b/soundcloud-wrapper-tauri/src-tauri/src/lib.rs
@@ -473,7 +473,8 @@ pub fn run() {
                             title: payload.title.clone(),
                             artist: payload.artist.clone(),
                             album: None,
-                            discogs_payload: None,
+                            discogs_release_id: None,
+                            discogs_confidence: None,
                         };
                         let source_record = SoundcloudSourceRecord {
                             track_id: payload.track_id.clone(),
@@ -515,7 +516,8 @@ pub fn run() {
                                 title: track.title.clone(),
                                 artist: track.artist.clone(),
                                 album: None,
-                                discogs_payload: None,
+                                discogs_release_id: None,
+                                discogs_confidence: None,
                             };
                             let source_record = SoundcloudSourceRecord {
                                 track_id: track.track_id.clone(),


### PR DESCRIPTION
## Summary
- add Discogs match and candidate tables with indices and migrate existing payloads into them
- extend library data structures and persistence to record Discogs matches and list candidates
- expose Discogs decisions on tracks while updating Tauri handlers to the new DTOs

## Testing
- cargo fmt
- cargo check *(fails: missing glib-2.0/gobject-2.0 system libraries in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbc7396d4832589fbe6d625efc859