### PR TITLE
Add MusicBrainz metadata support to library store

### DIFF
--- a/soundcloud-wrapper-tauri/src-tauri/src/lib.rs
+++ b/soundcloud-wrapper-tauri/src-tauri/src/lib.rs
@@ -494,6 +494,9 @@ pub fn run() {
                             album: None,
                             discogs_release_id: None,
                             discogs_confidence: None,
+                            musicbrainz_release_id: None,
+                            musicbrainz_confidence: None,
+                            musicbrainz_payload: None,
                         };
                         let source_record = SoundcloudSourceRecord {
                             track_id: payload.track_id.clone(),
@@ -537,6 +540,9 @@ pub fn run() {
                                 album: None,
                                 discogs_release_id: None,
                                 discogs_confidence: None,
+                                musicbrainz_release_id: None,
+                                musicbrainz_confidence: None,
+                                musicbrainz_payload: None,
                             };
                             let source_record = SoundcloudSourceRecord {
                                 track_id: track.track_id.clone(),

--- a/soundcloud-wrapper-tauri/src/App.tsx
+++ b/soundcloud-wrapper-tauri/src/App.tsx
@@ -23,6 +23,11 @@ type LibraryStatusRow = {
   discogsConfidence?: number | null;
   discogsCheckedAt?: string | null;
   discogsMessage?: string | null;
+  musicbrainzStatus?: string | null;
+  musicbrainzReleaseId?: string | null;
+  musicbrainzConfidence?: number | null;
+  musicbrainzCheckedAt?: string | null;
+  musicbrainzMessage?: string | null;
   soundcloudPermalinkUrl?: string | null;
   soundcloudLikedAt?: string | null;
   localLocation?: string | null;


### PR DESCRIPTION
## Summary
- extend track and library status models to carry MusicBrainz metadata fields alongside existing Discogs data
- create MusicBrainz match and candidate tables with migrations and migrate cached payloads into the normalized schema
- update queries and frontend types to surface MusicBrainz information

## Testing
- `cargo check` *(fails: missing system packages for gobject-2.0 / glib-2.0 required by gtk dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc858080083258911335f3793a078