### PR TITLE
Integrate MusicBrainz into library status and UI

### DIFF
--- a/soundcloud-wrapper-tauri/src-tauri/src/lib.rs
+++ b/soundcloud-wrapper-tauri/src-tauri/src/lib.rs
@@ -13,8 +13,9 @@ use std::time::Duration;
 
 use discogs::DiscogsService;
 use library::{
-    LibraryStatusPage, LibraryStore, LocalAssetRecord, SoundcloudLookupRecord,
-    SoundcloudSourceRecord, StatusFilter, TrackRecord,
+    DiscogsCandidateRecord, LibraryStatusPage, LibraryStore, LocalAssetRecord,
+    MusicbrainzCandidateRecord, SoundcloudLookupRecord, SoundcloudSourceRecord, StatusFilter,
+    TrackRecord,
 };
 use media::{MediaCache, MediaIntegration, MediaUpdate, MediaUpdatePayload, ThemeChangePayload};
 use musicbrainz::MusicbrainzService;
@@ -475,6 +476,34 @@ fn list_library_status(
 }
 
 #[tauri::command]
+fn list_discogs_candidates(
+    state: tauri::State<AppState>,
+    track_id: String,
+) -> Result<Vec<DiscogsCandidateRecord>, String> {
+    let store = state
+        .library
+        .lock()
+        .map_err(|_| "library store lock poisoned".to_string())?;
+    store
+        .list_discogs_candidates(&track_id)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+fn list_musicbrainz_candidates(
+    state: tauri::State<AppState>,
+    track_id: String,
+) -> Result<Vec<MusicbrainzCandidateRecord>, String> {
+    let store = state
+        .library
+        .lock()
+        .map_err(|_| "library store lock poisoned".to_string())?;
+    store
+        .list_musicbrainz_candidates(&track_id)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
 async fn import_rekordbox_library(
     state: tauri::State<'_, AppState>,
     db_path: String,
@@ -586,6 +615,8 @@ pub fn run() {
             refresh_soundcloud_likes,
             retry_discogs_lookup,
             retry_musicbrainz_lookup,
+            list_discogs_candidates,
+            list_musicbrainz_candidates,
             confirm_musicbrainz_match,
             upsert_track,
             link_soundcloud_source,

--- a/soundcloud-wrapper-tauri/src/App.tsx
+++ b/soundcloud-wrapper-tauri/src/App.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 const DISCOGS_AMBIGUITY_EVENT = "app://discogs/lookup-ambiguous";
+const MUSICBRAINZ_AMBIGUITY_EVENT = "app://musicbrainz/lookup-ambiguous";
 const JOB_PROGRESS_EVENT = "app://jobs/progress";
 const DEFAULT_PAGE_SIZE = 50;
 
@@ -23,11 +24,15 @@ type LibraryStatusRow = {
   discogsConfidence?: number | null;
   discogsCheckedAt?: string | null;
   discogsMessage?: string | null;
+  discogsQuery?: string | null;
+  discogsCandidateCount?: number;
   musicbrainzStatus?: string | null;
   musicbrainzReleaseId?: string | null;
   musicbrainzConfidence?: number | null;
   musicbrainzCheckedAt?: string | null;
   musicbrainzMessage?: string | null;
+  musicbrainzQuery?: string | null;
+  musicbrainzCandidateCount?: number;
   soundcloudPermalinkUrl?: string | null;
   soundcloudLikedAt?: string | null;
   localLocation?: string | null;
@@ -60,6 +65,12 @@ type DiscogsAmbiguityEvent = {
   candidates: Record<string, unknown>[];
 };
 
+type MusicbrainzAmbiguityEvent = {
+  trackId: string;
+  query?: string;
+  candidates: Record<string, unknown>[];
+};
+
 type DiscogsCandidate = {
   matchId: string;
   releaseId?: string;
@@ -71,6 +82,29 @@ type DiscogsCandidate = {
   resourceUrl?: string;
   rawPayload: Record<string, unknown>;
 };
+
+type MusicbrainzCandidatePayload = {
+  matchId: string;
+  releaseId?: string | null;
+  score?: number | null;
+  rawPayload?: Record<string, unknown> | null;
+};
+
+type MusicbrainzCandidate = {
+  matchId: string;
+  releaseId?: string;
+  score?: number;
+  title?: string;
+  date?: string;
+  country?: string;
+  disambiguation?: string;
+  artist?: string;
+  label?: string;
+  releaseUrl?: string;
+  rawPayload: Record<string, unknown>;
+};
+
+type CandidateSource = "discogs" | "musicbrainz";
 
 type JobProgressPayload = {
   id?: string;
@@ -97,7 +131,7 @@ type AsyncState<T> =
   | { status: "error"; message: string }
   | { status: "ready"; data: T };
 
-const normalizeCandidate = (candidate: DiscogsCandidatePayload): DiscogsCandidate => {
+const normalizeDiscogsCandidate = (candidate: DiscogsCandidatePayload): DiscogsCandidate => {
   const raw = candidate.rawPayload ?? {};
   const title = typeof raw.title === "string" ? raw.title : undefined;
   const year = typeof raw.year === "number" ? raw.year : undefined;
@@ -120,6 +154,62 @@ const normalizeCandidate = (candidate: DiscogsCandidatePayload): DiscogsCandidat
   };
 };
 
+const normalizeMusicbrainzCandidate = (
+  candidate: MusicbrainzCandidatePayload
+): MusicbrainzCandidate => {
+  const raw = candidate.rawPayload ?? {};
+  const title = typeof raw.title === "string" ? raw.title : undefined;
+  const date = typeof raw.date === "string" ? raw.date : undefined;
+  const country = typeof raw.country === "string" ? raw.country : undefined;
+  const disambiguation =
+    typeof raw.disambiguation === "string" ? raw.disambiguation : undefined;
+  const releaseId =
+    candidate.releaseId ?? (typeof raw.id === "string" ? raw.id : undefined);
+  const score = typeof candidate.score === "number" ? candidate.score : undefined;
+
+  let artist: string | undefined;
+  const artistCredit = raw["artist-credit"];
+  if (Array.isArray(artistCredit) && artistCredit.length > 0) {
+    const primary = artistCredit[0];
+    if (primary && typeof primary === "object" && typeof primary.name === "string") {
+      artist = primary.name;
+    }
+  }
+
+  let label: string | undefined;
+  const labelInfo = raw["label-info"];
+  if (Array.isArray(labelInfo) && labelInfo.length > 0) {
+    const primary = labelInfo[0];
+    if (
+      primary &&
+      typeof primary === "object" &&
+      primary.label &&
+      typeof primary.label === "object" &&
+      typeof primary.label.name === "string"
+    ) {
+      label = primary.label.name;
+    }
+  }
+
+  const releaseUrl = releaseId
+    ? `https://musicbrainz.org/release/${encodeURIComponent(releaseId)}`
+    : undefined;
+
+  return {
+    matchId: candidate.matchId,
+    releaseId: releaseId ?? undefined,
+    score,
+    title,
+    date,
+    country,
+    disambiguation,
+    artist,
+    label,
+    releaseUrl,
+    rawPayload: raw,
+  };
+};
+
 const formatDate = (value?: string | null) => {
   if (!value) {
     return "Sin datos";
@@ -131,9 +221,65 @@ const formatDate = (value?: string | null) => {
   return parsed.toLocaleString();
 };
 
-const Badge = ({ label, variant }: { label: string; variant: "primary" | "success" | "warning" | "neutral" }) => (
-  <span className={`badge badge--${variant}`}>{label}</span>
-);
+const formatScore = (value?: number | null) => {
+  if (typeof value !== "number") {
+    return "N/A";
+  }
+  return `${value.toFixed(1)} pts`;
+};
+
+const describeStatus = (status?: string | null) => {
+  switch (status) {
+    case "success":
+      return "Éxito";
+    case "ambiguous":
+      return "Revisión pendiente";
+    case "error":
+      return "Error";
+    default:
+      return "Sin verificar";
+  }
+};
+
+const getDiscogsStatusBadge = (status?: string | null) => {
+  if (!status) {
+    return null;
+  }
+  switch (status) {
+    case "success":
+      return { label: "Discogs", variant: "success" as const };
+    case "ambiguous":
+      return { label: "Discogs?", variant: "warning" as const };
+    case "error":
+      return { label: "Discogs error", variant: "danger" as const };
+    default:
+      return { label: "Discogs", variant: "neutral" as const };
+  }
+};
+
+const getMusicbrainzStatusBadge = (status?: string | null) => {
+  if (!status) {
+    return null;
+  }
+  switch (status) {
+    case "success":
+      return { label: "MusicBrainz", variant: "success" as const };
+    case "ambiguous":
+      return { label: "MusicBrainz?", variant: "warning" as const };
+    case "error":
+      return { label: "MusicBrainz error", variant: "danger" as const };
+    default:
+      return { label: "MusicBrainz", variant: "neutral" as const };
+  }
+};
+
+const Badge = ({
+  label,
+  variant,
+}: {
+  label: string;
+  variant: "primary" | "success" | "warning" | "neutral" | "danger";
+}) => <span className={`badge badge--${variant}`}>{label}</span>;
 
 const Checkbox = ({
   id,
@@ -184,8 +330,17 @@ const App = () => {
   const [loadingTracks, setLoadingTracks] = useState(false);
   const [trackError, setTrackError] = useState<string | null>(null);
   const [selectedTrackId, setSelectedTrackId] = useState<Nullable<string>>(null);
-  const [candidateCache, setCandidateCache] = useState<Record<string, DiscogsCandidate[]>>({});
-  const [candidateState, setCandidateState] = useState<AsyncState<DiscogsCandidate[]>>({ status: "idle" });
+  const [discogsCandidateCache, setDiscogsCandidateCache] = useState<Record<string, DiscogsCandidate[]>>({});
+  const [musicbrainzCandidateCache, setMusicbrainzCandidateCache] = useState<
+    Record<string, MusicbrainzCandidate[]>
+  >({});
+  const [discogsCandidateState, setDiscogsCandidateState] = useState<AsyncState<DiscogsCandidate[]>>({
+    status: "idle",
+  });
+  const [musicbrainzCandidateState, setMusicbrainzCandidateState] = useState<
+    AsyncState<MusicbrainzCandidate[]>
+  >({ status: "idle" });
+  const [activeCandidateSource, setActiveCandidateSource] = useState<CandidateSource>("discogs");
   const [jobs, setJobs] = useState<Record<string, JobRecord>>({});
   const [statusMessage, setStatusMessage] = useState<Nullable<{ type: "success" | "error" | "info"; text: string }>>(null);
 
@@ -224,7 +379,8 @@ const App = () => {
         const nextOffset = (response.offset ?? offset) + response.rows.length;
         setCurrentOffset(nextOffset);
         if (replace) {
-          setCandidateState({ status: "idle" });
+          setDiscogsCandidateState({ status: "idle" });
+          setMusicbrainzCandidateState({ status: "idle" });
         }
       } catch (error) {
         setTrackError(getErrorMessage(error));
@@ -258,7 +414,7 @@ const App = () => {
         if (!payload || !payload.trackId) {
           return;
         }
-        setCandidateCache((previous) => ({
+        setDiscogsCandidateCache((previous) => ({
           ...previous,
           [payload.trackId]: (payload.candidates || []).map((candidate) => {
             const rawId =
@@ -277,7 +433,7 @@ const App = () => {
                 : typeof candidate.score === "string"
                 ? Number.parseFloat(candidate.score)
                 : undefined;
-            return normalizeCandidate({
+            return normalizeDiscogsCandidate({
               matchId: payload.trackId,
               rawPayload: candidate,
               releaseId: rawId,
@@ -304,6 +460,59 @@ const App = () => {
       }
     };
   }, [attachDiscogsListener]);
+
+  const attachMusicbrainzListener = useCallback(async () => {
+    try {
+      const unlistenPromise = listen<MusicbrainzAmbiguityEvent>(
+        MUSICBRAINZ_AMBIGUITY_EVENT,
+        (event) => {
+          const payload = event.payload;
+          if (!payload || !payload.trackId) {
+            return;
+          }
+          setMusicbrainzCandidateCache((previous) => ({
+            ...previous,
+            [payload.trackId]: (payload.candidates || []).map((candidate) => {
+              const rawScore =
+                typeof candidate.score === "number"
+                  ? candidate.score
+                  : typeof candidate.score === "string"
+                  ? Number.parseFloat(candidate.score)
+                  : undefined;
+              const releaseId =
+                typeof candidate.releaseId === "string"
+                  ? candidate.releaseId
+                  : typeof candidate.id === "string"
+                  ? candidate.id
+                  : undefined;
+              return normalizeMusicbrainzCandidate({
+                matchId: payload.trackId,
+                rawPayload: candidate,
+                releaseId,
+                score: rawScore,
+              });
+            }),
+          }));
+        }
+      );
+      return unlistenPromise;
+    } catch (error) {
+      console.warn("No se pudo suscribir a eventos de MusicBrainz", error);
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    attachMusicbrainzListener().then((dispose) => {
+      unlisten = dispose ?? null;
+    });
+    return () => {
+      if (unlisten) {
+        unlisten();
+      }
+    };
+  }, [attachMusicbrainzListener]);
 
   useEffect(() => {
     const attachJobListener = async () => {
@@ -359,41 +568,238 @@ const App = () => {
     };
   }, []);
 
-  const loadCandidates = useCallback(
+  const loadDiscogsCandidates = useCallback(
     async (trackId: string) => {
-      if (candidateCache[trackId]) {
-        setCandidateState({ status: "ready", data: candidateCache[trackId] });
+      if (discogsCandidateCache[trackId]) {
+        setDiscogsCandidateState({
+          status: "ready",
+          data: discogsCandidateCache[trackId],
+        });
         return;
       }
-      setCandidateState({ status: "loading" });
+      setDiscogsCandidateState({ status: "loading" });
       try {
         const response = await invoke<DiscogsCandidatePayload[]>("list_discogs_candidates", {
           trackId,
         });
-        const normalized = response.map(normalizeCandidate);
-        setCandidateCache((previous) => ({ ...previous, [trackId]: normalized }));
-        setCandidateState({ status: "ready", data: normalized });
+        const normalized = response.map(normalizeDiscogsCandidate);
+        setDiscogsCandidateCache((previous) => ({ ...previous, [trackId]: normalized }));
+        setDiscogsCandidateState({ status: "ready", data: normalized });
       } catch (error) {
-        setCandidateState({ status: "error", message: getErrorMessage(error) });
+        setDiscogsCandidateState({ status: "error", message: getErrorMessage(error) });
       }
     },
-    [candidateCache]
+    [discogsCandidateCache]
+  );
+
+  const loadMusicbrainzCandidates = useCallback(
+    async (trackId: string) => {
+      if (musicbrainzCandidateCache[trackId]) {
+        setMusicbrainzCandidateState({
+          status: "ready",
+          data: musicbrainzCandidateCache[trackId],
+        });
+        return;
+      }
+      setMusicbrainzCandidateState({ status: "loading" });
+      try {
+        const response = await invoke<MusicbrainzCandidatePayload[]>(
+          "list_musicbrainz_candidates",
+          {
+            trackId,
+          }
+        );
+        const normalized = response.map(normalizeMusicbrainzCandidate);
+        setMusicbrainzCandidateCache((previous) => ({ ...previous, [trackId]: normalized }));
+        setMusicbrainzCandidateState({ status: "ready", data: normalized });
+      } catch (error) {
+        setMusicbrainzCandidateState({ status: "error", message: getErrorMessage(error) });
+      }
+    },
+    [musicbrainzCandidateCache]
   );
 
   useEffect(() => {
     if (!selectedTrackId) {
-      setCandidateState({ status: "idle" });
+      setDiscogsCandidateState({ status: "idle" });
+      setMusicbrainzCandidateState({ status: "idle" });
       return;
     }
-    loadCandidates(selectedTrackId).catch((error) => {
-      setCandidateState({ status: "error", message: getErrorMessage(error) });
+    loadDiscogsCandidates(selectedTrackId).catch((error) => {
+      setDiscogsCandidateState({ status: "error", message: getErrorMessage(error) });
     });
-  }, [selectedTrackId, loadCandidates]);
+    loadMusicbrainzCandidates(selectedTrackId).catch((error) => {
+      setMusicbrainzCandidateState({ status: "error", message: getErrorMessage(error) });
+    });
+  }, [selectedTrackId, loadDiscogsCandidates, loadMusicbrainzCandidates]);
 
   const selectedTrack = useMemo(
     () => tracks.find((row) => row.trackId === selectedTrackId) ?? null,
     [tracks, selectedTrackId]
   );
+
+  const hasIntegrationConflict = useMemo(() => {
+    if (!selectedTrack) {
+      return false;
+    }
+    if (!selectedTrack.discogsReleaseId || !selectedTrack.musicbrainzReleaseId) {
+      return false;
+    }
+    return selectedTrack.discogsReleaseId !== selectedTrack.musicbrainzReleaseId;
+  }, [selectedTrack]);
+
+  const discogsStatusInfo = selectedTrack
+    ? getDiscogsStatusBadge(selectedTrack.discogsStatus)
+    : null;
+  const musicbrainzStatusInfo = selectedTrack
+    ? getMusicbrainzStatusBadge(selectedTrack.musicbrainzStatus)
+    : null;
+  const discogsCandidateTotal =
+    discogsCandidateState.status === "ready"
+      ? discogsCandidateState.data.length
+      : selectedTrack?.discogsCandidateCount ?? 0;
+  const musicbrainzCandidateTotal =
+    musicbrainzCandidateState.status === "ready"
+      ? musicbrainzCandidateState.data.length
+      : selectedTrack?.musicbrainzCandidateCount ?? 0;
+
+  const renderDiscogsCandidates = () => {
+    switch (discogsCandidateState.status) {
+      case "loading":
+        return <p className="detail-card__empty">Cargando candidatos…</p>;
+      case "error":
+        return (
+          <p className="detail-card__error">
+            {"message" in discogsCandidateState
+              ? discogsCandidateState.message
+              : "Error al cargar candidatos"}
+          </p>
+        );
+      case "ready":
+        if (discogsCandidateState.data.length === 0) {
+          return <p className="detail-card__empty">No hay candidatos pendientes para esta pista.</p>;
+        }
+        return (
+          <ul className="candidate-list">
+            {discogsCandidateState.data.map((candidate) => (
+              <li
+                key={`${candidate.matchId}-${candidate.releaseId || candidate.title}`}
+                className="candidate-list__item"
+              >
+                <div className="candidate-list__main">
+                  <div className="candidate-list__info">
+                    <h4>{candidate.title || "Sin título"}</h4>
+                    <p className="candidate-list__meta">
+                      {candidate.year ? `${candidate.year}` : "Año desconocido"}
+                      {candidate.country ? ` · ${candidate.country}` : ""}
+                      {typeof candidate.score === "number" ? ` · ${candidate.score.toFixed(1)} pts` : ""}
+                    </p>
+                    {candidate.resourceUrl && (
+                      <a className="link" href={candidate.resourceUrl} target="_blank" rel="noreferrer">
+                        Abrir en Discogs
+                      </a>
+                    )}
+                  </div>
+                  {candidate.thumb && (
+                    <img src={candidate.thumb} alt="Carátula" className="candidate-list__thumb" />
+                  )}
+                </div>
+                <div className="candidate-list__actions">
+                  <button
+                    type="button"
+                    className="button button--small"
+                    onClick={() => handleConfirmDiscogsCandidate(candidate)}
+                    disabled={!candidate.releaseId}
+                  >
+                    Confirmar coincidencia
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        );
+      default:
+        return <p className="detail-card__empty">Selecciona una pista para ver candidatos.</p>;
+    }
+  };
+
+  const renderMusicbrainzCandidates = () => {
+    switch (musicbrainzCandidateState.status) {
+      case "loading":
+        return <p className="detail-card__empty">Cargando candidatos…</p>;
+      case "error":
+        return (
+          <p className="detail-card__error">
+            {"message" in musicbrainzCandidateState
+              ? musicbrainzCandidateState.message
+              : "Error al cargar candidatos"}
+          </p>
+        );
+      case "ready":
+        if (musicbrainzCandidateState.data.length === 0) {
+          return <p className="detail-card__empty">No hay candidatos pendientes para esta pista.</p>;
+        }
+        return (
+          <ul className="candidate-list">
+            {musicbrainzCandidateState.data.map((candidate) => (
+              <li key={`${candidate.matchId}-${candidate.releaseId || candidate.title}`} className="candidate-list__item">
+                <div className="candidate-list__main">
+                  <div className="candidate-list__info">
+                    <h4>{candidate.title || "Sin título"}</h4>
+                    <p className="candidate-list__meta">
+                      {candidate.artist ? candidate.artist : "Artista desconocido"}
+                      {candidate.date ? ` · ${candidate.date}` : ""}
+                      {candidate.country ? ` · ${candidate.country}` : ""}
+                      {typeof candidate.score === "number" ? ` · ${candidate.score.toFixed(1)} pts` : ""}
+                    </p>
+                    {candidate.label && <p className="candidate-list__submeta">{candidate.label}</p>}
+                    {candidate.disambiguation && (
+                      <p className="candidate-list__note">{candidate.disambiguation}</p>
+                    )}
+                    {candidate.releaseUrl && (
+                      <a className="link" href={candidate.releaseUrl} target="_blank" rel="noreferrer">
+                        Abrir en MusicBrainz
+                      </a>
+                    )}
+                  </div>
+                </div>
+                <div className="candidate-list__actions">
+                  <button
+                    type="button"
+                    className="button button--small"
+                    onClick={() => handleConfirmMusicbrainzCandidate(candidate)}
+                    disabled={!candidate.releaseId}
+                  >
+                    Confirmar coincidencia
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        );
+      default:
+        return <p className="detail-card__empty">Selecciona una pista para ver candidatos.</p>;
+    }
+  };
+
+  useEffect(() => {
+    if (!selectedTrack) {
+      return;
+    }
+    if (
+      selectedTrack.musicbrainzStatus === "ambiguous" &&
+      (selectedTrack.musicbrainzCandidateCount ?? 0) > 0
+    ) {
+      setActiveCandidateSource("musicbrainz");
+      return;
+    }
+    if (
+      selectedTrack.discogsStatus === "ambiguous" &&
+      (selectedTrack.discogsCandidateCount ?? 0) > 0
+    ) {
+      setActiveCandidateSource("discogs");
+    }
+  }, [selectedTrack]);
 
   const hasMore = tracks.length < totalTracks;
 
@@ -446,7 +852,7 @@ const App = () => {
     });
   }, [fetchTracks]);
 
-  const handleConfirmCandidate = async (candidate: DiscogsCandidate) => {
+  const handleConfirmDiscogsCandidate = async (candidate: DiscogsCandidate) => {
     if (!selectedTrackId || !candidate.releaseId) {
       setStatusMessage({ type: "error", text: "Selecciona un candidato válido." });
       return;
@@ -458,11 +864,38 @@ const App = () => {
         candidate: candidate.rawPayload,
       });
       setStatusMessage({ type: "success", text: "Coincidencia confirmada en Discogs" });
-      setCandidateCache((previous) => {
+      setDiscogsCandidateCache((previous) => {
         const clone = { ...previous };
         delete clone[selectedTrackId];
         return clone;
       });
+      setDiscogsCandidateState({ status: "idle" });
+      refreshCurrentPage();
+    } catch (error) {
+      setStatusMessage({ type: "error", text: getErrorMessage(error) });
+    }
+  };
+
+  const handleConfirmMusicbrainzCandidate = async (candidate: MusicbrainzCandidate) => {
+    if (!selectedTrackId) {
+      setStatusMessage({ type: "error", text: "Selecciona un candidato válido." });
+      return;
+    }
+    try {
+      const track = tracks.find((row) => row.trackId === selectedTrackId);
+      await invoke("confirm_musicbrainz_match", {
+        trackId: selectedTrackId,
+        release: candidate.rawPayload,
+        confidence: candidate.score,
+        query: track?.musicbrainzQuery ?? null,
+      });
+      setStatusMessage({ type: "success", text: "Coincidencia confirmada en MusicBrainz" });
+      setMusicbrainzCandidateCache((previous) => {
+        const clone = { ...previous };
+        delete clone[selectedTrackId];
+        return clone;
+      });
+      setMusicbrainzCandidateState({ status: "idle" });
       refreshCurrentPage();
     } catch (error) {
       setStatusMessage({ type: "error", text: getErrorMessage(error) });
@@ -476,11 +909,12 @@ const App = () => {
     try {
       await invoke("ignore_discogs_track", { trackId: selectedTrackId });
       setStatusMessage({ type: "info", text: "Pista marcada como ignorada" });
-      setCandidateCache((previous) => {
+      setDiscogsCandidateCache((previous) => {
         const clone = { ...previous };
         delete clone[selectedTrackId];
         return clone;
       });
+      setDiscogsCandidateState({ status: "idle" });
       refreshCurrentPage();
     } catch (error) {
       setStatusMessage({ type: "error", text: getErrorMessage(error) });
@@ -494,6 +928,44 @@ const App = () => {
     try {
       await invoke("download_track_assets", { trackId: selectedTrackId });
       setStatusMessage({ type: "success", text: "Descarga solicitada" });
+    } catch (error) {
+      setStatusMessage({ type: "error", text: getErrorMessage(error) });
+    }
+  };
+
+  const handleRetryDiscogs = async () => {
+    if (!selectedTrackId) {
+      return;
+    }
+    try {
+      await invoke("retry_discogs_lookup", { trackId: selectedTrackId });
+      setStatusMessage({ type: "success", text: "Búsqueda en Discogs reintentada" });
+      setDiscogsCandidateCache((previous) => {
+        const clone = { ...previous };
+        delete clone[selectedTrackId];
+        return clone;
+      });
+      setDiscogsCandidateState({ status: "loading" });
+      await loadDiscogsCandidates(selectedTrackId);
+    } catch (error) {
+      setStatusMessage({ type: "error", text: getErrorMessage(error) });
+    }
+  };
+
+  const handleRetryMusicbrainz = async () => {
+    if (!selectedTrackId) {
+      return;
+    }
+    try {
+      await invoke("retry_musicbrainz_lookup", { trackId: selectedTrackId });
+      setStatusMessage({ type: "success", text: "Búsqueda en MusicBrainz reintentada" });
+      setMusicbrainzCandidateCache((previous) => {
+        const clone = { ...previous };
+        delete clone[selectedTrackId];
+        return clone;
+      });
+      setMusicbrainzCandidateState({ status: "loading" });
+      await loadMusicbrainzCandidates(selectedTrackId);
     } catch (error) {
       setStatusMessage({ type: "error", text: getErrorMessage(error) });
     }
@@ -551,6 +1023,12 @@ const App = () => {
             <ul className="track-list">
               {tracks.map((row) => {
                 const isSelected = row.trackId === selectedTrackId;
+                const discogsBadge = getDiscogsStatusBadge(row.discogsStatus);
+                const musicbrainzBadge = getMusicbrainzStatusBadge(row.musicbrainzStatus);
+                const conflict =
+                  row.discogsReleaseId &&
+                  row.musicbrainzReleaseId &&
+                  row.discogsReleaseId !== row.musicbrainzReleaseId;
                 return (
                   <li
                     key={row.trackId}
@@ -561,13 +1039,15 @@ const App = () => {
                     <div className="track-list__meta">{row.artist || "Artista desconocido"}</div>
                     <div className="track-list__badges">
                       {row.liked && <Badge label="Like" variant="primary" />}
-                      {row.matched && <Badge label="Discogs" variant="success" />}
+                      {discogsBadge && <Badge label={discogsBadge.label} variant={discogsBadge.variant} />}
+                      {musicbrainzBadge && <Badge label={musicbrainzBadge.label} variant={musicbrainzBadge.variant} />}
                       {row.hasLocalFile ? (
                         <Badge label={row.localAvailable ? "Archivo local" : "Archivo no disponible"} variant={row.localAvailable ? "success" : "warning"} />
                       ) : (
                         <Badge label="Sin archivo" variant="warning" />
                       )}
                       {row.inRekordbox && <Badge label="Rekordbox" variant="neutral" />}
+                      {conflict && <Badge label="Conflicto" variant="warning" />}
                     </div>
                   </li>
                 );
@@ -608,16 +1088,24 @@ const App = () => {
                 </div>
                 <div className="track-detail__badges">
                   {selectedTrack.liked && <Badge label="Like" variant="primary" />}
-                  {selectedTrack.matched && <Badge label="Discogs" variant="success" />}
+                  {discogsStatusInfo && <Badge label={discogsStatusInfo.label} variant={discogsStatusInfo.variant} />}
+                  {musicbrainzStatusInfo && <Badge label={musicbrainzStatusInfo.label} variant={musicbrainzStatusInfo.variant} />}
                   {selectedTrack.hasLocalFile && (
                     <Badge label={selectedTrack.localAvailable ? "Archivo local" : "Archivo no disponible"} variant={selectedTrack.localAvailable ? "success" : "warning"} />
                   )}
                   {selectedTrack.inRekordbox && <Badge label="Rekordbox" variant="neutral" />}
+                  {hasIntegrationConflict && <Badge label="Conflicto" variant="warning" />}
                 </div>
               </header>
               <div className="track-detail__grid">
                 <article className="detail-card">
                   <h3>Información general</h3>
+                  {hasIntegrationConflict && (
+                    <div className="detail-card__alert detail-card__alert--warning">
+                      Se detectó un conflicto entre los lanzamientos confirmados en Discogs y MusicBrainz.
+                      Revisa y alinea las coincidencias para garantizar metadatos consistentes.
+                    </div>
+                  )}
                   <dl className="detail-list">
                     <div>
                       <dt>Álbum</dt>
@@ -625,19 +1113,59 @@ const App = () => {
                     </div>
                     <div>
                       <dt>Estado Discogs</dt>
-                      <dd>{selectedTrack.discogsStatus || "Sin verificar"}</dd>
+                      <dd>{describeStatus(selectedTrack.discogsStatus)}</dd>
                     </div>
                     <div>
-                      <dt>Confianza</dt>
-                      <dd>{selectedTrack.discogsConfidence ? `${selectedTrack.discogsConfidence.toFixed(1)}%` : "N/A"}</dd>
+                      <dt>Lanzamiento Discogs</dt>
+                      <dd>{selectedTrack.discogsReleaseId || "Sin datos"}</dd>
                     </div>
                     <div>
-                      <dt>Última comprobación</dt>
+                      <dt>Confianza Discogs</dt>
+                      <dd>{formatScore(selectedTrack.discogsConfidence)}</dd>
+                    </div>
+                    <div>
+                      <dt>Candidatos Discogs</dt>
+                      <dd>{selectedTrack.discogsCandidateCount ?? 0}</dd>
+                    </div>
+                    <div>
+                      <dt>Última comprobación Discogs</dt>
                       <dd>{formatDate(selectedTrack.discogsCheckedAt)}</dd>
                     </div>
                     <div>
-                      <dt>Mensaje</dt>
+                      <dt>Mensaje Discogs</dt>
                       <dd>{selectedTrack.discogsMessage || "—"}</dd>
+                    </div>
+                    <div>
+                      <dt>Consulta Discogs</dt>
+                      <dd>{selectedTrack.discogsQuery || "Sin datos"}</dd>
+                    </div>
+                    <div>
+                      <dt>Estado MusicBrainz</dt>
+                      <dd>{describeStatus(selectedTrack.musicbrainzStatus)}</dd>
+                    </div>
+                    <div>
+                      <dt>Lanzamiento MusicBrainz</dt>
+                      <dd>{selectedTrack.musicbrainzReleaseId || "Sin datos"}</dd>
+                    </div>
+                    <div>
+                      <dt>Confianza MusicBrainz</dt>
+                      <dd>{formatScore(selectedTrack.musicbrainzConfidence)}</dd>
+                    </div>
+                    <div>
+                      <dt>Candidatos MusicBrainz</dt>
+                      <dd>{selectedTrack.musicbrainzCandidateCount ?? 0}</dd>
+                    </div>
+                    <div>
+                      <dt>Última comprobación MusicBrainz</dt>
+                      <dd>{formatDate(selectedTrack.musicbrainzCheckedAt)}</dd>
+                    </div>
+                    <div>
+                      <dt>Mensaje MusicBrainz</dt>
+                      <dd>{selectedTrack.musicbrainzMessage || "—"}</dd>
+                    </div>
+                    <div>
+                      <dt>Consulta MusicBrainz</dt>
+                      <dd>{selectedTrack.musicbrainzQuery || "Sin datos"}</dd>
                     </div>
                     <div>
                       <dt>Like en SoundCloud</dt>
@@ -667,52 +1195,46 @@ const App = () => {
                   </dl>
                 </article>
                 <article className="detail-card">
-                  <h3>Candidatos de Discogs</h3>
-                  {candidateState.status === "loading" && <p className="detail-card__empty">Cargando candidatos…</p>}
-                  {candidateState.status === "error" && <p className="detail-card__error">{candidateState.message}</p>}
-                  {candidateState.status === "ready" && candidateState.data.length === 0 && (
-                    <p className="detail-card__empty">No hay candidatos pendientes para esta pista.</p>
-                  )}
-                  {candidateState.status === "ready" && candidateState.data.length > 0 && (
-                    <ul className="candidate-list">
-                      {candidateState.data.map((candidate) => (
-                        <li key={`${candidate.matchId}-${candidate.releaseId || candidate.title}`} className="candidate-list__item">
-                          <div className="candidate-list__main">
-                            <div className="candidate-list__info">
-                              <h4>{candidate.title || "Sin título"}</h4>
-                              <p className="candidate-list__meta">
-                                {candidate.year ? `${candidate.year}` : "Año desconocido"}
-                                {candidate.country ? ` · ${candidate.country}` : ""}
-                                {typeof candidate.score === "number" ? ` · ${candidate.score.toFixed(1)} pts` : ""}
-                              </p>
-                              {candidate.resourceUrl && (
-                                <a className="link" href={candidate.resourceUrl} target="_blank" rel="noreferrer">
-                                  Abrir en Discogs
-                                </a>
-                              )}
-                            </div>
-                            {candidate.thumb && <img src={candidate.thumb} alt="Carátula" className="candidate-list__thumb" />}
-                          </div>
-                          <div className="candidate-list__actions">
-                            <button
-                              type="button"
-                              className="button button--small"
-                              onClick={() => handleConfirmCandidate(candidate)}
-                              disabled={!candidate.releaseId}
-                            >
-                              Confirmar coincidencia
-                            </button>
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                  <div className="candidate-card__header">
+                    <h3>Candidatos</h3>
+                    <div className="candidate-tabs">
+                      <button
+                        type="button"
+                        className={`candidate-tabs__button ${
+                          activeCandidateSource === "discogs" ? "candidate-tabs__button--active" : ""
+                        }`}
+                        onClick={() => setActiveCandidateSource("discogs")}
+                      >
+                        Discogs ({discogsCandidateTotal})
+                      </button>
+                      <button
+                        type="button"
+                        className={`candidate-tabs__button ${
+                          activeCandidateSource === "musicbrainz" ? "candidate-tabs__button--active" : ""
+                        }`}
+                        onClick={() => setActiveCandidateSource("musicbrainz")}
+                      >
+                        MusicBrainz ({musicbrainzCandidateTotal})
+                      </button>
+                    </div>
+                  </div>
+                  <div className="candidate-panel">
+                    {activeCandidateSource === "discogs"
+                      ? renderDiscogsCandidates()
+                      : renderMusicbrainzCandidates()}
+                  </div>
                 </article>
                 <article className="detail-card">
                   <h3>Acciones</h3>
                   <div className="detail-actions">
                     <button type="button" className="button button--secondary" onClick={handleDownloadTrack}>
                       Descargar pista
+                    </button>
+                    <button type="button" className="button button--secondary" onClick={handleRetryDiscogs}>
+                      Reintentar Discogs
+                    </button>
+                    <button type="button" className="button button--secondary" onClick={handleRetryMusicbrainz}>
+                      Reintentar MusicBrainz
                     </button>
                     <button type="button" className="button button--ghost" onClick={handleIgnoreTrack}>
                       Ignorar pista en Discogs

--- a/soundcloud-wrapper-tauri/src/styles.css
+++ b/soundcloud-wrapper-tauri/src/styles.css
@@ -187,6 +187,11 @@ button {
   color: #e2e8f0;
 }
 
+.badge--danger {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fecaca;
+}
+
 .sidebar__error,
 .sidebar__loading {
   margin-top: 0.75rem;
@@ -358,6 +363,20 @@ button {
   color: rgba(148, 163, 184, 0.9);
 }
 
+.detail-card__alert {
+  margin: 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.detail-card__alert--warning {
+  background: rgba(251, 191, 36, 0.15);
+  color: #fde68a;
+  border: 1px solid rgba(251, 191, 36, 0.35);
+}
+
 .detail-list {
   margin: 0;
   display: grid;
@@ -410,6 +429,46 @@ button {
   text-decoration: underline;
 }
 
+.candidate-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.candidate-tabs {
+  display: inline-flex;
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.candidate-tabs__button {
+  border: none;
+  background: transparent;
+  color: rgba(148, 163, 184, 0.85);
+  padding: 0.4rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.candidate-tabs__button:hover {
+  background: rgba(56, 189, 248, 0.2);
+  color: #e0f2fe;
+}
+
+.candidate-tabs__button--active {
+  background: rgba(56, 189, 248, 0.3);
+  color: #0f172a;
+}
+
+.candidate-panel {
+  margin-top: 0.75rem;
+}
+
 .candidate-list {
   list-style: none;
   margin: 0;
@@ -444,6 +503,18 @@ button {
   margin: 0.35rem 0 0;
   font-size: 0.85rem;
   color: rgba(148, 163, 184, 0.8);
+}
+
+.candidate-list__submeta {
+  margin: 0.2rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.candidate-list__note {
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(253, 230, 138, 0.9);
 }
 
 .candidate-list__thumb {


### PR DESCRIPTION
## Summary
- extend the SQLite library status listing to include Discogs and MusicBrainz queries, candidate counts, and expose stored candidates
- add IPC commands for listing Discogs and MusicBrainz candidates and reuse the MusicBrainz confirm endpoint
- overhaul the dashboard UI to surface combined integration state, candidate review tabs, conflict alerts, and updated styling

## Testing
- cargo fmt --manifest-path src-tauri/Cargo.toml
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de4e438ffc8325a0ebe400c50d9216