### PR TITLE
Run tests before building Tauri bundles

### DIFF
--- a/soundcloud-wrapper-tauri/.github/workflows/tauri-build.yml
+++ b/soundcloud-wrapper-tauri/.github/workflows/tauri-build.yml
@@ -1,4 +1,5 @@
-name: Build desktop bundles
+# Builds platform bundles after verifying npm tests, type checks, and cargo tests locally.
+name: Build desktop bundles (tests run before packaging)
 
 on:
   workflow_dispatch:
@@ -50,6 +51,17 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Prepare test cache directories
+        run: mkdir -p .cache/vitest
+
+      - name: Cache Vitest artifacts
+        uses: actions/cache@v4
+        with:
+          path: .cache/vitest
+          key: ${{ runner.os }}-vitest-${{ hashFiles('soundcloud-wrapper-tauri/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vitest-
 
       - name: Cache cargo directories
         uses: actions/cache@v4

--- a/soundcloud-wrapper-tauri/.gitignore
+++ b/soundcloud-wrapper-tauri/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.cache/
 
 # Tauri
 src-tauri/target

--- a/soundcloud-wrapper-tauri/scripts/build-linux.sh
+++ b/soundcloud-wrapper-tauri/scripts/build-linux.sh
@@ -6,7 +6,14 @@ PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 pushd "$PROJECT_ROOT" >/dev/null
 
+vitest_cache_dir="${PROJECT_ROOT}/.cache/vitest"
+mkdir -p "$vitest_cache_dir"
+export VITEST_CACHE_DIR="$vitest_cache_dir"
+
 npm ci
+npm run test
+npm run build
+cargo test --workspace --manifest-path src-tauri/Cargo.toml
 cargo tauri build --bundles appimage deb rpm "$@"
 
 if [[ -n "${LINUX_SIGNING_KEY_ID:-}" ]]; then

--- a/soundcloud-wrapper-tauri/scripts/build-macos.sh
+++ b/soundcloud-wrapper-tauri/scripts/build-macos.sh
@@ -8,6 +8,10 @@ export RUSTFLAGS="${RUSTFLAGS:-}"
 
 pushd "$PROJECT_ROOT" >/dev/null
 
+vitest_cache_dir="${PROJECT_ROOT}/.cache/vitest"
+mkdir -p "$vitest_cache_dir"
+export VITEST_CACHE_DIR="$vitest_cache_dir"
+
 if [[ -n "${APPLE_IDENTITY:-}" ]]; then
   export TAURI_SIGNING_IDENTITY="$APPLE_IDENTITY"
 fi
@@ -25,6 +29,9 @@ if [[ -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
 fi
 
 npm ci
+npm run test
+npm run build
+cargo test --workspace --manifest-path src-tauri/Cargo.toml
 cargo tauri build --bundles dmg "$@"
 
 popd >/dev/null

--- a/soundcloud-wrapper-tauri/scripts/build-windows.ps1
+++ b/soundcloud-wrapper-tauri/scripts/build-windows.ps1
@@ -11,7 +11,14 @@ $projectRoot = Resolve-Path "$scriptDir/.."
 
 Push-Location $projectRoot
 
+$vitestCacheDir = Join-Path $projectRoot '.cache/vitest'
+New-Item -ItemType Directory -Path $vitestCacheDir -Force | Out-Null
+$env:VITEST_CACHE_DIR = $vitestCacheDir
+
 npm ci
+npm run test
+npm run build
+cargo test --workspace --manifest-path src-tauri/Cargo.toml
 cargo tauri build --bundles msi @args
 
 $bundleDir = Join-Path $projectRoot 'src-tauri/target/release/bundle/msi'


### PR DESCRIPTION
## Summary
- ensure the platform build scripts run npm tests, type checks, and cargo workspace tests before invoking `cargo tauri build`
- cache Vitest artifacts and document the new pre-build requirements in the desktop bundling workflow
- ignore the Vitest cache directory so local runs do not dirty the tree

## Testing
- npm run test *(fails: qa plan expectations do not match repository state)*
- cargo test --workspace --manifest-path src-tauri/Cargo.toml *(fails: missing system `glib-2.0` dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de529096208325ac205a1349286f68