### PR TITLE
Document architecture and MusicBrainz setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,59 @@
 SoundCloud Wrapper Desktop is a cross-platform application built with Tauri. It delivers a lightweight native experience for listening to SoundCloud inside the system WebView while integrating with media controls, the system tray, and native notifications without depending on external browsers.
 
 ## Architecture
-- **Rust backend (Tauri 2):** Manages the application lifecycle, registers global shortcuts, controls the tray icon, injects a custom script when SoundCloud loads, and exposes a hardened `open_external` command that launches links in the default browser.
-- **Lightweight frontend with Vite + TypeScript:** Packages a minimal interface that embeds `https://soundcloud.com` and shows a placeholder while the integration finishes loading.
-- **Injection bridge:** The `inject.js` script tracks the `MediaSession` state, emits events back to Rust, intercepts external links so they open outside the app, and triggers SoundCloud UI buttons so playback commands stay in sync.
+- **SoundCloud bridge:** The preload/injection script (`inject.js`) mounts inside the embedded SoundCloud session, synchronises playback state through Tauri IPC, mirrors likes/playlist actions into the local library cache, and guards outbound links so they open in the system browser.
+- **Discogs worker:** A Rust background task queue (`DiscogsService`) throttles requests to the Discogs API, reconciles candidate releases against the local store, and notifies the UI when manual intervention is required.
+- **MusicBrainz service (alpha):** A companion Rust client (`MusicbrainzService`) is being introduced to mirror the Discogs enrichment flow. It requires first-party credentials and is currently optional in production builds while the API contract settles.
+- **Rust/Tauri host:** Coordinates the application lifecycle, tray/menu integration, global media shortcuts, and hardened shell commands while exposing a typed IPC surface to the frontend.
+- **Vite + TypeScript frontend:** Provides the minimal chrome around the SoundCloud WebView, renders the library tooling, and surfaces enrichment status coming from the Discogs/MusicBrainz background workers.
 - **Platform-specific integrations:** The media module delegates to MPRIS (Linux), SMTC (Windows), and the macOS media APIs to reflect playback status and receive commands from the operating system.
 
 ## Requirements
 ### Common
 - Node.js 18 or newer and npm (or pnpm/yarn) to run the Vite/Tauri scripts.
 - Stable Rust and `tauri-cli` (installed automatically via npm).
+- Rust `cargo` and system toolchains capable of compiling GTK/WebKit dependencies (Tauri downloads the platform WebView bindings as needed).
 - (Optional) A SoundCloud account to test sign-in within the WebView.
 
 ### Windows
 - Windows 10/11 with the **WebView2 Runtime** installed (even if Microsoft Edge is already available).
 - Microsoft Visual C++ Build Tools 2019 or newer.
+- Optional: Windows SDK signing tools (`signtool.exe`) when running the release scripts.
 
 ### macOS
 - macOS 10.15 Catalina or newer (per `tauri.conf.json`).
 - Xcode Command Line Tools installed (`clang`, `swift`, and codesign utilities).
+- Optional: Full Xcode if you plan to notarise or staple DMGs in CI.
 
 ### Linux
 - A distribution that ships WebKitGTK 4.1 (for example Ubuntu 22.04+ or Fedora 38+).
 - Required packages: `libwebkit2gtk-4.1`, `libgtk-3-dev`, `libsoup-3.0`, `webkit2gtk-driver`, `libayatana-appindicator3` (declared as a dependency of the `.deb` package).
+- Optional: GPG tooling (`gnupg`, `gpg`) when signing Linux bundles through the helper scripts.
+
+## Configuration and secrets
+The enrichment workers depend on authenticated calls in local builds and CI. Export the following variables (for example via `.env`, your shell profile, or CI secrets) before starting the desktop app or the test/build scripts:
+
+| Variable | Purpose |
+| --- | --- |
+| `MUSICBRAINZ_APP_NAME` | Application name sent in the MusicBrainz user agent header. |
+| `MUSICBRAINZ_APP_VERSION` | Semantic version advertised to MusicBrainz. |
+| `MUSICBRAINZ_APP_CONTACT` | Contact e-mail or URL associated with the MusicBrainz application. |
+| `MUSICBRAINZ_TOKEN` | Personal access token used for authenticated MusicBrainz lookups. |
+
+See [`docs/musicbrainz-credentials.md`](soundcloud-wrapper-tauri/docs/musicbrainz-credentials.md) for step-by-step guidance on creating and storing these credentials for both local development and automation runners.
+
+Release automation scripts consume the usual platform-specific secrets documented in [`docs/release-signing.md`](soundcloud-wrapper-tauri/docs/release-signing.md): Apple notarisation credentials (`APPLE_IDENTITY`, `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`), Windows code-signing certificates (`SIGNING_CERTIFICATE_PATH`, `SIGNING_CERTIFICATE_PASSWORD`, `TIMESTAMP_URL`), and optional Linux signing keys (`LINUX_SIGNING_KEY_ID`).
+
+## CI-equivalent test and build pipeline
+To mirror the continuous-integration workflow locally, run the commands below from `soundcloud-wrapper-tauri/` after installing dependencies:
+
+```bash
+npm run test
+cargo test --workspace --manifest-path src-tauri/Cargo.toml
+npm run tauri:build
+```
+
+This sequence executes the Vitest suite, runs the Rust workspace tests (matching the CI manifest path), and produces signed release bundles for the current platform.
 
 ## Installation and usage
 1. Clone the repository and enter the project root.

--- a/soundcloud-wrapper-tauri/docs/musicbrainz-credentials.md
+++ b/soundcloud-wrapper-tauri/docs/musicbrainz-credentials.md
@@ -1,0 +1,48 @@
+# MusicBrainz credential setup
+
+SoundCloud Wrapper Desktop enriches the local library with release metadata fetched from the MusicBrainz API. This document explains how to obtain the required credentials and wire them into local development, CI jobs, and release builds.
+
+## 1. Create a MusicBrainz application
+1. Sign in to your [MusicBrainz account](https://musicbrainz.org/login).
+2. Navigate to **Profile → Applications** and click **Add application**.
+3. Fill the following fields:
+   - **Application name**: a descriptive identifier such as `SoundCloud Wrapper Desktop`.
+   - **Application version**: follow [SemVer](https://semver.org/) (for example `0.5.0`).
+   - **Contact method**: a monitored e-mail address or URL the MusicBrainz team can use to reach you.
+4. Submit the form and note the generated token. You can regenerate it later if it is compromised.
+
+## 2. Required environment variables
+The Rust `MusicbrainzService` reads four environment variables at startup:
+
+| Variable | Description |
+| --- | --- |
+| `MUSICBRAINZ_APP_NAME` | Propagated to the user-agent string when calling MusicBrainz. |
+| `MUSICBRAINZ_APP_VERSION` | Advertised application version (match the release tag where possible). |
+| `MUSICBRAINZ_APP_CONTACT` | Contact value configured when creating the application. |
+| `MUSICBRAINZ_TOKEN` | Personal access token returned by MusicBrainz. |
+
+Set these variables before running `npm run tauri:dev`, the automated tests, or any of the release scripts. Missing values disable MusicBrainz lookups and surface warnings in the application logs.
+
+### Local development
+Create a `.env.local` (ignored by Git) in `soundcloud-wrapper-tauri/` or export the values via your shell profile:
+
+```bash
+export MUSICBRAINZ_APP_NAME="SoundCloud Wrapper Desktop"
+export MUSICBRAINZ_APP_VERSION="0.5.0"
+export MUSICBRAINZ_APP_CONTACT="dev@example.com"
+export MUSICBRAINZ_TOKEN="paste-token-here"
+```
+
+Reload your terminal session before running the desktop app so the environment variables propagate to Tauri.
+
+### Continuous integration
+Store the same values as encrypted secrets in your CI provider. When mirroring the project pipeline (`npm run test && cargo test --workspace --manifest-path src-tauri/Cargo.toml && npm run tauri:build`), export the variables in the job definition so both Vitest and the Rust integration tests can reach MusicBrainz.
+
+### Release scripts
+The helper scripts in `scripts/` automatically forward the environment variables to `cargo tauri build`. Ensure the values are present alongside platform-specific signing credentials:
+
+- `scripts/build-macos.sh` respects `APPLE_IDENTITY`, `APPLE_TEAM_ID`, and MusicBrainz variables during the notarised build.
+- `scripts/build-windows.ps1` consumes Windows signing secrets (`SIGNING_CERTIFICATE_PATH`, `SIGNING_CERTIFICATE_PASSWORD`, `TIMESTAMP_URL`) in addition to the MusicBrainz variables for metadata lookups.
+- `scripts/build-linux.sh` optionally signs the generated packages when `LINUX_SIGNING_KEY_ID` is set and keeps MusicBrainz lookups enabled by inheriting the exported variables.
+
+For shared runners, prefer injecting the variables via secure secret managers rather than storing them in plaintext files.


### PR DESCRIPTION
## Summary
- expand the root README with an updated architecture overview and CI-mirroring build instructions
- document the required MusicBrainz environment variables and link to new credential setup notes
- clarify platform-specific dependencies and how release scripts consume signing secrets

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68de540b8e88832592b2d9dbb3ef7d6c